### PR TITLE
Add Vite Rails Legacy, which targets Rails 4

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -3,6 +3,7 @@
 [webpacker]: https://github.com/rails/webpacker
 [vite rails]: https://github.com/ElMassimo/vite_ruby
 [vite]: https://vitejs.dev/
+[vite_rails_legacy]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_rails_legacy
 [vite_hanami]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_hanami
 [vite_ruby]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_ruby
 [commands]: /guide/development.html#cli-commands-⌨%EF%B8%8F
@@ -44,6 +45,7 @@ And then run:
 
 - If using Hanami, install the <kbd>[vite_hanami]</kbd> gem instead.
 - If using other Ruby web frameworks, install the <kbd>[vite_ruby]</kbd> gem.
+- If using Rails 4, install the <kbd>[vite_rails_legacy]</kbd> gem.
 
 ### Setup 📦
 

--- a/vite_rails/README.md
+++ b/vite_rails/README.md
@@ -80,7 +80,7 @@ Visit the [documentation website][website] to check out the [guides] and searcha
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'vite_rails'
+gem 'vite_rails' # vite_rails_legacy if using Rails 4
 ```
 
 Then, run:

--- a/vite_rails_legacy/CHANGELOG.md
+++ b/vite_rails_legacy/CHANGELOG.md
@@ -1,0 +1,3 @@
+## ViteRailsLegacy 2.0.2  (2020-02-11)
+
+- Release a version of Vite Rails that supports Rails 4.

--- a/vite_rails_legacy/LICENSE.txt
+++ b/vite_rails_legacy/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Maximo Mussini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vite_rails_legacy/README.md
+++ b/vite_rails_legacy/README.md
@@ -1,0 +1,50 @@
+<h1 align="center">
+  <a href="https://vite-ruby.netlify.app/">
+    <img src="https://raw.githubusercontent.com/ElMassimo/vite_ruby/main/docs/public/logo.svg" width="120px"/>
+  </a>
+
+  <br>
+
+  <a href="https://vite-ruby.netlify.app/">
+    Vite Rails Legacy
+  </a>
+
+  <br>
+
+  <p align="center">
+    <a href="https://github.com/ElMassimo/vite_ruby/actions">
+      <img alt="Build Status" src="https://github.com/ElMassimo/vite_ruby/workflows/build/badge.svg"/>
+    </a>
+    <a href="https://codeclimate.com/github/ElMassimo/vite_ruby">
+      <img alt="Maintainability" src="https://codeclimate.com/github/ElMassimo/vite_ruby/badges/gpa.svg"/>
+    </a>
+    <a href="https://codeclimate.com/github/ElMassimo/vite_ruby">
+      <img alt="Test Coverage" src="https://codeclimate.com/github/ElMassimo/vite_ruby/badges/coverage.svg"/>
+    </a>
+    <a href="https://rubygems.org/gems/vite_rails_legacy">
+      <img alt="Gem Version" src="https://img.shields.io/gem/v/vite_rails_legacy.svg?colorB=e9573f"/>
+    </a>
+    <a href="https://github.com/ElMassimo/vite_ruby/blob/master/LICENSE.txt">
+      <img alt="License" src="https://img.shields.io/badge/license-MIT-428F7E.svg"/>
+    </a>
+  </p>
+</h1>
+
+[vite_rails]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_rails
+[vite_ruby]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_ruby
+
+__Vite Rails Legacy__ is [__Vite Rails__][vite_rails], modified to support Rails 4.
+
+## Why a separate library? 🤔
+
+I don't want the burden of having to support Rails 4 in the main codebase.
+
+And yet, after extracting [_Vite Ruby_][vite_ruby] the surface area is smaller,
+and it was easy to adapt it to work with Rails 4.
+
+This way, people get to use the library in Rails 4, and I get to not worry about
+accidentally breaking support with changes that are tested on Rails 5 and onwards.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/vite_rails_legacy/Rakefile
+++ b/vite_rails_legacy/Rakefile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+
+class Bundler::GemHelper
+  def version_tag
+    "vite_rails_legacy@#{ version }"
+  end
+end

--- a/vite_rails_legacy/lib/tasks/vite.rake
+++ b/vite_rails_legacy/lib/tasks/vite.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Set NODE_ENV before installation, so that Rails installs JS build dependencies
+# on servers that precompile assets.
+installation_tasks = ['yarn:install', 'webpacker:yarn_install'].select { |name| Rake::Task.task_defined?(name) }.each do |name|
+  Rake::Task[name].enhance([:'vite_rails:set_node_env'])
+end
+
+# Ensure dependencies are installed in older versions of Rails
+Rake::Task['assets:precompile']&.enhance([:'vite:install_dependencies']) if installation_tasks.none?
+
+require 'vite_ruby'
+ViteRuby.install_tasks
+
+namespace :vite_rails do
+  desc 'Fixes Rails management of node dev dependencies (build dependencies)'
+  task :set_node_env do
+    ENV['NODE_ENV'] = 'development'
+  end
+end

--- a/vite_rails_legacy/lib/vite_rails_legacy.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'vite_ruby'
+
+require 'vite_rails_legacy/version'
+require 'vite_rails_legacy/config'
+require 'vite_rails_legacy/tag_helpers'
+require 'vite_rails_legacy/engine' if defined?(Rails)
+
+# Active Support 4 does not support multiple arguments in append.
+class Array
+  alias append push
+end

--- a/vite_rails_legacy/lib/vite_rails_legacy/config.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ViteRailsLegacy::Config
+  # Override: Default values for a Rails application.
+  def config_defaults
+    require 'rails'
+    super(
+      asset_host: Rails.application&.config&.action_controller&.asset_host,
+      mode: Rails.env.to_s,
+      root: Rails.root || Dir.pwd,
+    )
+  end
+end
+
+ViteRuby::Config.singleton_class.prepend(ViteRailsLegacy::Config)

--- a/vite_rails_legacy/lib/vite_rails_legacy/engine.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/engine.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails/railtie'
+
+class ViteRailsLegacy::Engine < Rails::Engine
+  initializer 'vite_rails.proxy' do |app|
+    app.middleware.insert_before 0, 'ViteRuby::DevServerProxy', ssl_verify_none: true if ViteRuby.run_proxy?
+  end
+
+  initializer 'vite_rails_legacy.helper' do
+    ActiveSupport.on_load(:action_controller) do
+      ActionController::Base.helper(ViteRailsLegacy::TagHelpers)
+    end
+
+    ActiveSupport.on_load(:action_view) do
+      include ViteRailsLegacy::TagHelpers
+    end
+  end
+
+  initializer 'vite_rails.logger' do
+    config.after_initialize do
+      ViteRuby.instance.logger = Rails.logger
+    end
+  end
+
+  initializer 'vite_rails.bootstrap' do
+    if defined?(Rails::Server) || defined?(Rails::Console)
+      ViteRuby.bootstrap
+      if defined?(Spring)
+        require 'spring/watcher'
+        Spring.after_fork { ViteRuby.bootstrap }
+        Spring.watch(ViteRuby.config.config_path)
+      end
+    end
+  end
+end

--- a/vite_rails_legacy/lib/vite_rails_legacy/installation.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/installation.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'vite_rails_legacy'
+
+# Internal: Extends the base installation script from Vite Ruby to work for a
+# typical Rails app.
+module ViteRailsLegacy::Installation
+  RAILS_TEMPLATES = Pathname.new(File.expand_path('../../templates', __dir__))
+
+  # Override: Setup a typical apps/web Hanami app to use Vite.
+  def setup_app_files
+    cp RAILS_TEMPLATES.join('config/rails-vite.json'), config.config_path
+    if root.join('app/javascript').exist?
+      Dry::CLI::Utils::Files.replace_first_line config.config_path, 'app/frontend', %(    "sourceCodeDir": "app/javascript",)
+    end
+  end
+
+  # Override: Create a sample JS file and attempt to inject it in an HTML template.
+  def install_sample_files
+    unless config.resolved_entrypoints_dir.join('application.js').exist?
+      cp RAILS_TEMPLATES.join('entrypoints/application.js'), config.resolved_entrypoints_dir.join('application.js')
+    end
+
+    if (layout_file = root.join('app/views/layouts/application.html.erb')).exist?
+      inject_line_before layout_file, '</head>', <<-HTML
+    <%= vite_client_tag %>
+    <%= vite_javascript_tag 'application' %>
+      HTML
+    end
+  end
+end
+
+ViteRuby::CLI::Install.prepend(ViteRailsLegacy::Installation)

--- a/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
@@ -6,7 +6,7 @@ module ViteRailsLegacy::TagHelpers
   def vite_client_tag
     return unless src = vite_manifest.vite_client_src
 
-    "<script#{tag_options({ src: src, type: 'module' }, escape: true)}></script>".html_safe
+    "<script#{ tag_options({ src: src, type: 'module' }, escape: true) }></script>".html_safe
   end
 
   # Public: Resolves the path for the specified Vite asset.

--- a/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Public: Allows to render HTML tags for scripts and styles processed by Vite.
+module ViteRailsLegacy::TagHelpers
+  # Public: Renders a script tag for vite/client to enable HMR in development.
+  def vite_client_tag
+    return unless src = vite_manifest.vite_client_src
+
+    "<script#{tag_options({ src: src, type: 'module' }, escape: true)}></script>".html_safe
+  end
+
+  # Public: Resolves the path for the specified Vite asset.
+  #
+  # Example:
+  #   <%= vite_asset_path 'calendar.css' %> # => "/vite/assets/calendar-1016838bab065ae1e122.css"
+  def vite_asset_path(name, **options)
+    path_to_asset vite_manifest.path_for(name, **options)
+  end
+
+  # Public: Renders a <script> tag for the specified Vite entrypoints.
+  def vite_javascript_tag(*names,
+                          type: 'module',
+                          asset_type: :javascript,
+                          skip_preload_tags: false,
+                          skip_style_tags: false,
+                          crossorigin: 'anonymous',
+                          **options)
+    entries = vite_manifest.resolve_entries(*names, type: asset_type)
+    tags = javascript_include_tag(*entries.fetch(:scripts), crossorigin: crossorigin, type: type, **options)
+    tags << vite_preload_tag(*entries.fetch(:imports), crossorigin: crossorigin) unless skip_preload_tags
+    tags << stylesheet_link_tag(*entries.fetch(:stylesheets)) unless skip_style_tags
+    tags
+  end
+
+  # Public: Renders a <script> tag for the specified Vite entrypoints.
+  def vite_typescript_tag(*names, **options)
+    vite_javascript_tag(*names, asset_type: :typescript, extname: false, **options)
+  end
+
+  # Public: Renders a <link> tag for the specified Vite entrypoints.
+  def vite_stylesheet_tag(*names, **options)
+    style_paths = names.map { |name| vite_asset_path(name, type: :stylesheet) }
+    stylesheet_link_tag(*style_paths, **options)
+  end
+
+private
+
+  # Internal: Returns the current manifest loaded by Vite Ruby.
+  def vite_manifest
+    ViteRuby.instance.manifest
+  end
+
+  # Internal: Renders a modulepreload link tag.
+  def vite_preload_tag(*sources, crossorigin:)
+    sources.map { |source|
+      href = path_to_asset(source)
+      try(:request).try(:send_early_hints, 'Link' => %(<#{ href }>; rel=modulepreload; as=script; crossorigin=#{ crossorigin }))
+      tag('link', rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin)
+    }.join("\n").html_safe
+  end
+end

--- a/vite_rails_legacy/lib/vite_rails_legacy/version.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ViteRailsLegacy
+  VERSION = '2.0.2'
+end

--- a/vite_rails_legacy/templates/config/rails-vite.json
+++ b/vite_rails_legacy/templates/config/rails-vite.json
@@ -1,0 +1,15 @@
+{
+  "all": {
+    "sourceCodeDir": "app/frontend",
+    "watchAdditionalPaths": []
+  },
+  "development": {
+    "autoBuild": true,
+    "publicOutputDir": "vite-dev",
+    "port": 3036
+  },
+  "test": {
+    "autoBuild": true,
+    "publicOutputDir": "vite-test"
+  }
+}

--- a/vite_rails_legacy/templates/entrypoints/application.js
+++ b/vite_rails_legacy/templates/entrypoints/application.js
@@ -1,0 +1,22 @@
+// To see this message, add the following to the `<head>` section in your
+// views/layouts/application.html.erb
+//
+//    <%= vite_client_tag %>
+//    <%= vite_javascript_tag 'application' %>
+console.log('Vite ⚡️ Rails')
+
+// Example: Load Rails libraries in Vite.
+//
+// import '@rails/ujs'
+//
+// import Turbolinks from 'turbolinks'
+// import ActiveStorage from '@rails/activestorage'
+//
+// // Import all channels.
+// import.meta.globEager('./**/*_channel.js')
+//
+// Turbolinks.start()
+// ActiveStorage.start()
+
+// Example: Import a stylesheet in app/frontend/index.css
+// import '~/index.css'

--- a/vite_rails_legacy/vite_rails_legacy.gemspec
+++ b/vite_rails_legacy/vite_rails_legacy.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('./lib', __dir__)
+require 'vite_rails_legacy/version'
+
+Gem::Specification.new do |s|
+  s.name     = 'vite_rails_legacy'
+  s.version  = ViteRailsLegacy::VERSION
+  s.authors  = ['Máximo Mussini']
+  s.email    = ['maximomussini@gmail.com']
+  s.summary  = 'Use Vite in Rails 4 and bring joy to your JavaScript experience'
+  s.homepage = 'https://github.com/ElMassimo/vite_ruby'
+  s.license  = 'MIT'
+
+  s.metadata = {
+    'source_code_uri' => "https://github.com/ElMassimo/vite_ruby/tree/vite_rails_legacy@#{ ViteRailsLegacy::VERSION }/vite_rails_legacy",
+    'changelog_uri' => "https://github.com/ElMassimo/vite_ruby/blob/vite_rails_legacy@#{ ViteRailsLegacy::VERSION }/vite_rails_legacy/CHANGELOG.md",
+  }
+
+  s.required_ruby_version = Gem::Requirement.new('>= 2.5')
+
+  s.add_dependency 'railties', '< 5'
+  s.add_dependency 'vite_ruby'
+
+  s.add_development_dependency 'bundler', '>= 1.3.0'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-minitest'
+  s.add_development_dependency 'rubocop-performance'
+
+  s.files = Dir.glob('{lib,templates}/**/*') + %w[README.md CHANGELOG.md LICENSE.txt]
+  s.test_files = `git ls-files -- test/*`.split("\n")
+end


### PR DESCRIPTION
[vite_rails]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_rails
[vite_ruby]: https://github.com/ElMassimo/vite_ruby/tree/main/vite_ruby

### Description 📖

This pull request adds `vite_rails_legacy`, which is [__Vite Rails__][vite_rails], modified to support Rails 4.

## Why a separate library? 🤔

I don't want the burden of having to support Rails 4 in the main codebase.

And yet, after extracting [_Vite Ruby_][vite_ruby] the surface area is smaller,
and it was easy to adapt it to work with Rails 4.

This way, people get to use the library in Rails 4, and I get to not worry about
accidentally breaking support with changes that are tested on Rails 5 and onwards.

### Screenshots 📷

Running on Rails 4.2

<img width="601" alt="Screen Shot 2021-02-12 at 12 44 00" src="https://user-images.githubusercontent.com/1158253/107790090-29614e00-6d31-11eb-8f6c-88ecce90dbfb.png">

