### PR TITLE
Fix URLs in vite-plugin-ruby package

### DIFF
--- a/vite-plugin-ruby/package.json
+++ b/vite-plugin-ruby/package.json
@@ -9,10 +9,10 @@
   "author": "Máximo Mussini <maximomussini@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ElMasssimo/vite_rails/blob/master/vite-plugin-ruby"
+    "url": "https://github.com/ElMassimo/vite_rails/blob/main/vite-plugin-ruby"
   },
-  "homepage": "https://github.com/ElMasssimo/vite_rails/blob/master/vite-plugin-ruby",
-  "bugs": "https://github.com/ElMasssimo/vite_rails/issues",
+  "homepage": "https://github.com/ElMassimo/vite_rails/blob/main/vite-plugin-ruby",
+  "bugs": "https://github.com/ElMassimo/vite_rails/issues",
   "files": [
     "dist",
     "default.vite.json"


### PR DESCRIPTION
### Description 📖

This pull request fixes some broken URLs in `vite-plugin-ruby/package.json`.

Specifically, it changes `ElMasssimo` (3 "s"s) to `ElMassimo` (2 "s"s) and changes the branch name `master` to `main` (since there is no `master` branch and the default branch is `main`).

### Background 📜

I noticed this because when [dependabot](https://app.dependabot.com/) created [this PR](https://github.com/davidrunger/david_runger/pull/279), the links in the PR description (pointing [here](https://github.com/ElMasssimo/vite_rails) and [here](https://github.com/ElMasssimo/vite_rails/commits)) were 404ing.

### The Fix 🔨

I updated the URLs in `vite-plugin-ruby/package.json` to the appropriate URLs.

### Screenshots 📷

N/A