### PR TITLE
feat: Add paths in watchAdditionalPaths to configureServer (close #21)

### DIFF
--- a/vite-plugin-ruby/example/app/assets/theme.css
+++ b/vite-plugin-ruby/example/app/assets/theme.css
@@ -1,3 +1,7 @@
 :root {
   --color: #2c3e50;
 }
+
+.hidden {
+  display: none;
+}

--- a/vite-plugin-ruby/example/app/frontend/components/HelloWorld.vue
+++ b/vite-plugin-ruby/example/app/frontend/components/HelloWorld.vue
@@ -29,7 +29,7 @@ a {
     <a href="https://v3.vuejs.org/" target="_blank">Vue 3 Documentation</a>
   </p>
 
-  <p>
+  <p class="hidden">
     Recommended setup:
     <a href="https://code.visualstudio.com/" target="_blank">VSCode</a>
     +
@@ -43,7 +43,7 @@ a {
       target="_blank"
     >Vue DX</a>
   </p>
-  <p>
+  <p class="hidden">
     Make sure to use workspace version of TypeScript to get improved support via
     <a
       href="https://github.com/znck/vue-developer-experience"

--- a/vite-plugin-ruby/example/app/frontend/entrypoints/main.ts
+++ b/vite-plugin-ruby/example/app/frontend/entrypoints/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import App from '~/App.vue'
 import '~/entrypoints/app.css'
+import '@assets/theme.css'
 
 createApp(App).mount('#app')
 

--- a/vite-plugin-ruby/example/config/vite.json
+++ b/vite-plugin-ruby/example/config/vite.json
@@ -1,4 +1,9 @@
 {
+  "all": {
+    "watchAdditionalPaths": [
+      "app/assets/**/*"
+    ]
+  },
   "development": {
     "autoBuild": true,
     "publicOutputDir": "vite-dev",

--- a/vite-plugin-ruby/example/vite.config.ts
+++ b/vite-plugin-ruby/example/vite.config.ts
@@ -1,8 +1,14 @@
+import { resolve } from 'path'
 import { UserConfig } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 import ViteRuby from 'vite-plugin-ruby'
 
 const config: UserConfig = {
+  resolve: {
+    alias: {
+      '@assets/': `${resolve(process.cwd(), 'app/assets')}/`,
+    },
+  },
   plugins: [
     Vue(),
     ViteRuby(),

--- a/vite-plugin-ruby/src/types.ts
+++ b/vite-plugin-ruby/src/types.ts
@@ -10,6 +10,7 @@ export interface Config {
   https?: boolean
   port?: number
   publicOutputDir?: string
+  watchAdditionalPaths?: string[]
 }
 
 export interface PluginOptions {


### PR DESCRIPTION
### Description 📖

This pull request adds any paths in [`watchAdditionalPaths`](https://vite-ruby.netlify.app/config/#watchadditionalpaths) to [`server.watcher`](https://github.com/ElMassimo/vite_ruby/blob/main/vite-plugin-ruby/src/index.ts#L72), which ensures Vite detects changes and performs HMR or reload as needed.

It's useful for projects that import code outside the [`sourceCodeDir`](https://vite-ruby.netlify.app/config/#sourcecodedir).