### PR TITLE
Improve UX when running build command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,4 +213,4 @@ DEPENDENCIES
   vite_ruby!
 
 BUNDLED WITH
-   2.2.9
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    minitest-stub_any_instance (1.0.2)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -201,6 +202,7 @@ DEPENDENCIES
   m (~> 1.5)
   minitest (~> 5.0)
   minitest-reporters (~> 1.4)
+  minitest-stub_any_instance (~> 1.0)
   pry-byebug (~> 3.9)
   rails
   rake (~> 13.0)

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -3,14 +3,6 @@
 require 'test_helper'
 
 class CommandsTest < ViteRuby::Test
-  def stub_builder(stale:, build_with_vite:, &block)
-    ViteRuby::Build.stub_any_instance(:success, build_with_vite) {
-      ViteRuby::Build.stub_any_instance(:stale?, stale) {
-        ViteRuby::Builder.stub_any_instance(:build_with_vite, build_with_vite, &block)
-      }
-    }
-  end
-
   def test_bootstrap
     assert ViteRuby.bootstrap
   end
@@ -18,21 +10,27 @@ class CommandsTest < ViteRuby::Test
   delegate :build, :build_from_task, :clean, :clean_from_task, :clobber, to: 'ViteRuby.commands'
 
   def test_build_returns_success_status_when_stale
-    stub_builder(stale: true, build_with_vite: true) {
+    stub_builder(stale: true, build_successful: true) {
       assert build
       assert build_from_task
     }
   end
 
   def test_build_returns_success_status_when_fresh
-    stub_builder(stale: false, build_with_vite: true) {
+    stub_builder(stale: false, build_successful: true) {
       assert build
       assert build_from_task
     }
   end
 
+  def test_build_returns_failure_status_when_fresh
+    stub_builder(stale: false, build_successful: false) {
+      refute build
+    }
+  end
+
   def test_build_returns_failure_status_when_stale
-    stub_builder(stale: true, build_with_vite: false) {
+    stub_builder(stale: true, build_successful: false) {
       refute build
     }
   end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -4,9 +4,11 @@ require 'test_helper'
 
 class CommandsTest < ViteRuby::Test
   def stub_builder(stale:, build_with_vite:, &block)
-    ViteRuby.instance.builder.stub :stale?, stale do
-      ViteRuby.instance.builder.stub :build_with_vite, build_with_vite, &block
-    end
+    ViteRuby::Build.stub_any_instance(:success, build_with_vite) {
+      ViteRuby::Build.stub_any_instance(:stale?, stale) {
+        ViteRuby::Builder.stub_any_instance(:build_with_vite, build_with_vite, &block)
+      }
+    }
   end
 
   def test_bootstrap

--- a/test/engine_rake_tasks_test.rb
+++ b/test/engine_rake_tasks_test.rb
@@ -119,11 +119,16 @@ private
     root_dir.join('public/vite-dev')
   end
 
+  def tmp_dir
+    root_dir.join('tmp')
+  end
+
   def remove_vite_files
     vite_binstub_path.delete if vite_binstub_path.exist?
     vite_config_ts_path.delete if vite_config_ts_path.exist?
     app_frontend_dir.rmtree if app_frontend_dir.exist?
     app_public_dir.rmtree if app_public_dir.exist?
+    tmp_dir.rmtree if tmp_dir.exist?
     root_dir.join('app/views/layouts/application.html.erb').write(Pathname.new(test_app_path).join('app/views/layouts/application.html.erb').read)
     gitignore_path.write('')
     @command_results = []

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -93,6 +93,6 @@ private
   end
 
   def manifest_path
-    File.expand_path File.join(File.dirname(__FILE__), 'test_app/public/vite-production', 'manifest.json').to_s
+    'public/vite-production/manifest.json'
   end
 end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -20,4 +20,13 @@ class RunnerTest < ViteRuby::Test
       assert_run_command('build', '--emptyOutDir', flags: ['--mode', 'development'])
     end
   end
+
+  def test_command_capture
+    ViteRuby::Runner.stub_any_instance(:vite_executable, ['echo']) {
+      stdout, stderr, status = ViteRuby.run(['"Hello"'], capture: true)
+      assert_equal %("Hello" --mode production\n), stdout
+      assert_equal '', stderr
+      assert status.success?
+    }
+  end
 end

--- a/test/test_app/config/application.rb
+++ b/test/test_app/config/application.rb
@@ -5,6 +5,9 @@ require 'action_view/railtie'
 
 class Rails::Console; end
 
+require 'spring/configuration'
+Spring.application_root = File.expand_path('..', __dir__)
+
 require 'vite_rails'
 
 module TestApp

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,14 @@ class ViteRuby::Test < Minitest::Test
 
 private
 
+  def stub_builder(build_successful:, stale: false, &block)
+    ViteRuby::Build.stub_any_instance(:success, build_successful) {
+      ViteRuby::Build.stub_any_instance(:stale?, stale) {
+        ViteRuby::Builder.stub_any_instance(:build_with_vite, build_successful, &block)
+      }
+    }
+  end
+
   def assert_run_command(*argv, flags: [])
     Dir.chdir(test_app_path) {
       mock = Minitest::Mock.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start {
 
 require 'minitest/autorun'
 require 'minitest/reporters'
+require 'minitest/stub_any_instance'
 
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(color: true, location: true, fast_fail: true)]
 

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -28,7 +28,6 @@ class ViteRuby
 
     def_delegators :instance, :config, :commands, :run_proxy?
     def_delegators :config, :mode
-    def_delegators 'ViteRuby::Runner.new', :run
 
     def instance
       @instance ||= ViteRuby.new
@@ -50,6 +49,11 @@ class ViteRuby
     # Internal: Loads all available rake tasks.
     def install_tasks
       load File.expand_path('tasks/vite.rake', __dir__)
+    end
+
+    # Internal: Executes the vite binary.
+    def run(argv, **options)
+      ViteRuby::Runner.new(instance).run(argv, **options)
     end
 
     # Internal: Refreshes the config after setting the env vars.
@@ -74,9 +78,6 @@ class ViteRuby
       }.compact
     end
   end
-
-  extend Forwardable
-  def_delegators :builder, :build
 
   attr_writer :logger
 

--- a/vite_ruby/lib/vite_ruby/build.rb
+++ b/vite_ruby/lib/vite_ruby/build.rb
@@ -7,11 +7,6 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :digest, :current_digest) do
     new(attrs['success'], attrs['timestamp'] || 'never', attrs['digest'] || 'none', current_digest)
   end
 
-  # Internal: Returns a build object by parsing the information in the file.
-  def self.from(success:, timestamp:, digest:)
-    new(success, timestamp, digest)
-  end
-
   # Internal: Returns true if watched files have changed since the last build.
   def stale?
     digest != current_digest

--- a/vite_ruby/lib/vite_ruby/build.rb
+++ b/vite_ruby/lib/vite_ruby/build.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Internal: Value object with information about the last build.
+ViteRuby::Build = Struct.new(:success, :timestamp, :digest, :current_digest) do
+  # Internal: Combines information from a previous build with the current digest.
+  def self.from_previous(attrs, current_digest)
+    new(attrs['success'], attrs['timestamp'] || 'never', attrs['digest'] || 'none', current_digest)
+  end
+
+  # Internal: Returns a build object by parsing the information in the file.
+  def self.from(success:, timestamp:, digest:)
+    new(success, timestamp, digest)
+  end
+
+  # Internal: Returns true if watched files have changed since the last build.
+  def stale?
+    digest != current_digest
+  end
+
+  # Internal: Returns true if watched files have not changed since the last build.
+  def fresh?
+    !stale?
+  end
+
+  # Internal: Returns a new build with the specified result.
+  def with_result(success)
+    self.class.new(success, Time.now.strftime('%F %T'), current_digest)
+  end
+
+  # Internal: Returns a JSON string with the metadata of the build.
+  def to_json(*_args)
+    JSON.pretty_generate(to_h)
+  end
+end

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'digest/sha1'
 
 # Public: Keeps track of watched files and triggers builds as needed.
@@ -10,23 +11,33 @@ class ViteRuby::Builder
 
   # Public: Checks if the watched files have changed since the last compilation,
   # and triggers a Vite build if any files have changed.
-  def build
-    if stale?
-      build_with_vite.tap { record_files_digest }
-    else
-      logger.debug 'Skipping build. Vite assets are already up-to-date ⚡️'
+  def build(*args)
+    if fresh?(build = last_build)
+      if build['success']
+        logger.debug "Skipping vite build. Watched files have not changed since the last build at #{ build['timestamp'] }"
+      else
+        logger.error "Build with vite failed! Watched files have not changed since #{ build['timestamp'] } ❌"
+      end
       true
+    else
+      build_with_vite(*args).tap { |success| record_files_digest(success) }
     end
   end
 
   # Public: Returns true if all the assets built by Vite are up to date.
-  def fresh?
-    previous_files_digest&.== watched_files_digest
+  def fresh?(build = last_build)
+    build && build['digest'] == watched_files_digest
   end
 
   # Public: Returns true if any of the assets built by Vite is out of date.
   def stale?
     !fresh?
+  end
+
+  # Internal: Reads the result of the last compilation from disk.
+  def last_build
+    JSON.parse(files_digest_path.read.to_s) if files_digest_path.exist?
+  rescue JSON::JSONError, Errno::ENOENT, Errno::ENOTDIR
   end
 
 private
@@ -36,20 +47,15 @@ private
   def_delegators :@vite_ruby, :config, :logger
 
   # Internal: Writes a digest of the watched files to disk for future checks.
-  def record_files_digest
+  def record_files_digest(success)
     config.build_cache_dir.mkpath
-    files_digest_path.write(watched_files_digest)
+    build = { success: success, timestamp: Time.now.strftime('%F %T'), digest: watched_files_digest }
+    files_digest_path.write(build.to_json)
   end
 
   # Internal: The path of where a digest of the watched files is stored.
   def files_digest_path
-    config.build_cache_dir.join("last-compilation-digest-#{ config.mode }")
-  end
-
-  # Internal: Reads a digest of watched files from disk.
-  def previous_files_digest
-    files_digest_path.read if files_digest_path.exist? && config.manifest_path.exist?
-  rescue Errno::ENOENT, Errno::ENOTDIR
+    config.build_cache_dir.join("last-compilation-#{ config.mode }")
   end
 
   # Internal: Returns a digest of all the watched files, allowing to detect
@@ -65,11 +71,11 @@ private
   # Public: Initiates a Vite build command to generate assets.
   #
   # Returns true if the build is successful, or false if it failed.
-  def build_with_vite
+  def build_with_vite(*args)
     logger.info 'Building with Vite ⚡️'
 
-    stdout, stderr, status = ViteRuby.run(['build'], capture: true)
-    log_build_result(stdout, stderr, status)
+    stdout, stderr, status = ViteRuby.run(['build', *args], capture: true)
+    log_build_result(stdout, stderr.to_s, status)
 
     status.success?
   end
@@ -77,16 +83,14 @@ private
   # Internal: Outputs the build results.
   #
   # NOTE: By default it also outputs the manifest entries.
-  def log_build_result(stdout, stderr, status)
+  def log_build_result(_stdout, stderr, status)
     if status.success?
       logger.info "Build with Vite complete: #{ config.build_output_dir }"
-      logger.error(stderr.to_s) unless stderr.empty?
-      logger.info(stdout) unless config.hide_build_console_output
+      logger.error stderr.to_s unless stderr.empty?
     else
-      non_empty_streams = [stdout, stderr].delete_if(&:empty?)
-      errors = non_empty_streams.join("\n\n")
-      errors += "\n❌ Check that vite and vite-plugin-ruby are in devDependencies and have been installed. " if errors.include?('ERR! canceled')
-      logger.error "Build with Vite failed:\n#{ errors }"
+      logger.error stderr
+      logger.error 'Build with Vite failed! ❌'
+      logger.error '❌ Check that vite and vite-plugin-ruby are in devDependencies and have been installed. ' if stderr.include?('ERR! canceled')
     end
   end
 

--- a/vite_ruby/lib/vite_ruby/cli/build.rb
+++ b/vite_ruby/lib/vite_ruby/cli/build.rb
@@ -11,8 +11,8 @@ class ViteRuby::CLI::Build < Dry::CLI::Command
   desc 'Bundle all entrypoints using Vite.'
   shared_options
 
-  def call(mode:)
+  def call(mode:, args: [])
     ViteRuby.env['VITE_RUBY_MODE'] = mode
-    block_given? ? yield(mode) : ViteRuby.commands.build_from_task
+    block_given? ? yield(mode) : ViteRuby.commands.build_from_task(*args)
   end
 end

--- a/vite_ruby/lib/vite_ruby/cli/build.rb
+++ b/vite_ruby/lib/vite_ruby/cli/build.rb
@@ -6,13 +6,18 @@ class ViteRuby::CLI::Build < Dry::CLI::Command
 
   def self.shared_options
     option(:mode, default: self::DEFAULT_ENV, values: %w[development production], aliases: ['m'], desc: 'The build mode for Vite')
+    option(:debug, desc: 'Run Vite in verbose mode, printing all debugging output', aliases: ['verbose'], type: :boolean)
+    option(:inspect, desc: 'Run Vite in a debugging session with node --inspect-brk', aliases: ['inspect-brk'], type: :boolean)
+    option(:trace_deprecation, desc: 'Run Vite in debugging mode with node --trace-deprecation', aliases: ['trace-deprecation'], type: :boolean)
   end
 
   desc 'Bundle all entrypoints using Vite.'
   shared_options
+  option(:force, desc: 'Force the build even if assets have not changed', type: :boolean)
 
-  def call(mode:, args: [])
+  def call(mode:, args: [], **boolean_opts)
     ViteRuby.env['VITE_RUBY_MODE'] = mode
-    block_given? ? yield(mode) : ViteRuby.commands.build_from_task(*args)
+    boolean_opts.map { |name, value| args << "--#{ name }" if value }
+    block_given? ? yield(args) : ViteRuby.commands.build_from_task(*args)
   end
 end

--- a/vite_ruby/lib/vite_ruby/cli/dev.rb
+++ b/vite_ruby/lib/vite_ruby/cli/dev.rb
@@ -5,8 +5,9 @@ class ViteRuby::CLI::Dev < ViteRuby::CLI::Build
 
   desc 'Start the Vite development server.'
   shared_options
+  option(:force, desc: 'Force Vite to re-bundle dependencies', type: :boolean)
 
-  def call(mode:, args: [])
-    super(mode: mode) { ViteRuby.run(args) }
+  def call(**options)
+    super { |args| ViteRuby.run(args) }
   end
 end

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -150,7 +150,7 @@ private
 
   def ensure_log_goes_to_stdout
     old_logger = logger
-    self.logger = Logger.new($stdout)
+    self.logger = Logger.new($stdout, formatter: proc { |_, _, progname, msg| progname == 'vite' ? msg : "#{ msg }\n" })
     yield
   ensure
     self.logger = old_logger

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -149,10 +149,12 @@ private
   end
 
   def ensure_log_goes_to_stdout
-    old_logger = logger
+    old_logger, original_sync = logger, $stdout.sync
+
+    $stdout.sync = true
     self.logger = Logger.new($stdout, formatter: proc { |_, _, progname, msg| progname == 'vite' ? msg : "#{ msg }\n" })
     yield
   ensure
-    self.logger = old_logger
+    self.logger, $stdout.sync = old_logger, original_sync
   end
 end

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -8,17 +8,17 @@ class ViteRuby::Commands
   end
 
   # Public: Defaults to production, and exits if the build fails.
-  def build_from_task
+  def build_from_task(*args)
     with_node_env(ENV.fetch('NODE_ENV', 'production')) {
       ensure_log_goes_to_stdout {
-        build || exit!
+        build(*args) || exit!
       }
     }
   end
 
   # Public: Builds all assets that are managed by Vite, from the entrypoints.
-  def build
-    builder.build.tap { manifest.refresh }
+  def build(*args)
+    builder.build(*args).tap { manifest.refresh }
   end
 
   # Public: Removes all build cache and previously compiled assets.

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -9,7 +9,7 @@ class ViteRuby::DevServerProxy < Rack::Proxy
 
   def initialize(app = nil, options = {})
     @vite_ruby = options.delete(:vite_ruby) || ViteRuby.instance
-    options[:streaming] = false if ViteRuby.mode == 'test' && !options.key?(:streaming)
+    options[:streaming] = false if config.mode == 'test' && !options.key?(:streaming)
     super
   end
 

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -65,7 +65,7 @@ protected
   #   manifest.lookup('calendar.js')
   #   => { "file" => "/vite/assets/calendar-1016838bab065ae1e122.js", "imports" => [] }
   def lookup(name, type: nil)
-    build if should_build?
+    builder.build if should_build?
 
     find_manifest_entry(with_file_extension(name, type))
   end
@@ -74,7 +74,7 @@ private
 
   extend Forwardable
 
-  def_delegators :@vite_ruby, :config, :build, :dev_server_running?
+  def_delegators :@vite_ruby, :config, :builder, :dev_server_running?
 
   # NOTE: Auto compilation is convenient when running tests, when the developer
   # won't focus on the frontend, or when running the Vite server is not desired.

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -15,6 +15,7 @@ class ViteRuby::Manifest
 
   def initialize(vite_ruby)
     @vite_ruby = vite_ruby
+    @build_mutex = Mutex.new if config.auto_build
   end
 
   # Public: Returns the path for the specified Vite entrypoint file.
@@ -65,7 +66,7 @@ protected
   #   manifest.lookup('calendar.js')
   #   => { "file" => "/vite/assets/calendar-1016838bab065ae1e122.js", "imports" => [] }
   def lookup(name, type: nil)
-    builder.build if should_build?
+    @build_mutex.synchronize { builder.build } if should_build?
 
     find_manifest_entry(with_file_extension(name, type))
   end

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -149,35 +149,32 @@ private
 
       Possible causes:
       #{ possible_causes(last_build) }
+
       Visit the Troubleshooting guide for more information:
         https://vite-ruby.netlify.app/guide/troubleshooting.html#troubleshooting
-
-      Content in your manifests:
-      #{ JSON.pretty_generate(@manifest) }
-
-      Last build in #{ config.mode } mode:
-      #{ last_build.to_json }
+      #{ last_build.success && "\nContent in your manifests:\n#{ JSON.pretty_generate(@manifest) }\n" }
+      #{ !last_build.success.nil? && "\nLast build in #{ config.mode } mode:\n#{ last_build.to_json }\n" }
     MSG
   end
 
   def possible_causes(last_build)
     return FAILED_BUILD_CAUSES if last_build.success == false
-    return AUTO_BUILD_CAUSES if config.auto_build
+    return DEFAULT_CAUSES if config.auto_build
 
-    AUTO_BUILD_CAUSES + POSSIBLE_CAUSES
+    DEFAULT_CAUSES + NO_AUTO_BUILD_CAUSES
   end
 
   FAILED_BUILD_CAUSES = <<-MSG
   - The last build failed. Try running `bin/vite build --force` manually and check for errors.
   MSG
 
-  AUTO_BUILD_CAUSES = <<-MSG
+  DEFAULT_CAUSES = <<-MSG
   - The file path is incorrect.
   - The file is not in the entrypoints directory.
   - Some files are outside the sourceCodeDir, and have not been added to watchAdditionalPaths.
   MSG
 
-  POSSIBLE_CAUSES = <<-MSG
+  NO_AUTO_BUILD_CAUSES = <<-MSG
   - You have not run `bin/vite dev` to start Vite, or the dev server is not reachable.
   - "autoBuild" is set to `false` in your config/vite.json for this environment.
   MSG

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -144,25 +144,20 @@ private
     file_name = with_file_extension(name, type)
     raise ViteRuby::Manifest::MissingEntryError, <<~MSG
       Vite Ruby can't find #{ file_name } in #{ config.manifest_path } or #{ config.assets_manifest_path }.
-
-      Possible causes:
-      #{ missing_entry_causes.map { |cause| "\t- #{ cause }" }.join("\n") }
+      #{ config.auto_build && MISSING_ENTRY_POSSIBLE_CAUSES }
+      Last build in #{ config.mode } mode:
+      #{ JSON.pretty_generate(builder.last_build || 'no build found') }
 
       Content in your manifests:
       #{ JSON.pretty_generate(@manifest) }
     MSG
   end
 
-  def missing_entry_causes
-    local = config.auto_build
-    [
-      (dev_server_running? && 'Vite has not yet re-built your latest changes.'),
-      (local && !dev_server_running? && "\"autoBuild\": false in your #{ config.mode } configuration."),
-      (local && !dev_server_running? && 'The Vite development server has crashed or is no longer available.'),
-      'You have misconfigured config/vite.json file.',
-      (!local && 'Assets have not been precompiled'),
-    ].select(&:itself)
-  rescue StandardError
-    []
-  end
+  MISSING_ENTRY_POSSIBLE_CAUSES = <<~MSG
+
+    Possible causes:
+      - You have not run `bin/vite dev` to start Vite, it has crashed, or is running in a different port.
+      - "autoBuild" is set to `false` in your config/vite.json for this environment.
+      - The last build was not successful.
+  MSG
 end

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -149,11 +149,10 @@ private
 
       Possible causes:
       #{ possible_causes(last_build) }
-
       Visit the Troubleshooting guide for more information:
         https://vite-ruby.netlify.app/guide/troubleshooting.html#troubleshooting
-      #{ last_build.success && "\nContent in your manifests:\n#{ JSON.pretty_generate(@manifest) }\n" }
-      #{ !last_build.success.nil? && "\nLast build in #{ config.mode } mode:\n#{ last_build.to_json }\n" }
+      #{ "\nContent in your manifests:\n#{ JSON.pretty_generate(@manifest) }\n" if last_build.success }
+      #{ "\nLast build in #{ config.mode } mode:\n#{ last_build.to_json }\n" unless last_build.success.nil? }
     MSG
   end
 

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -147,7 +147,7 @@ private
       Vite Ruby can't find #{ file_name } in #{ config.manifest_path } or #{ config.assets_manifest_path }.
       #{ config.auto_build && MISSING_ENTRY_POSSIBLE_CAUSES }
       Last build in #{ config.mode } mode:
-      #{ JSON.pretty_generate(builder.last_build || 'no build found') }
+      #{ builder.last_build_metadata.to_json }
 
       Content in your manifests:
       #{ JSON.pretty_generate(@manifest) }

--- a/vite_ruby/lib/vite_ruby/runner.rb
+++ b/vite_ruby/lib/vite_ruby/runner.rb
@@ -9,10 +9,12 @@ class ViteRuby::Runner
   end
 
   # Public: Executes Vite with the specified arguments.
-  def run(argv, **options)
-    $stdout.sync = true
-    detect_unsupported_switches!(argv)
-    execute_command(argv.clone, **options)
+  def run(argv, capture: false)
+    if capture
+      capture3_with_output(*command_for(argv), chdir: config.root)
+    else
+      Dir.chdir(config.root) { Kernel.exec(*command_for(argv)) }
+    end
   end
 
 private
@@ -21,29 +23,10 @@ private
 
   def_delegators :@vite_ruby, :config, :logger
 
-  UNSUPPORTED_SWITCHES = %w[--host --port --https --root -r --config -c].freeze
-
-  # Internal: Allows to prevent configuration mistakes by ensuring the Ruby app
-  # and vite-plugin-ruby are using the same configuration for the dev server.
-  def detect_unsupported_switches!(args)
-    return unless (unsupported = UNSUPPORTED_SWITCHES & args).any?
-
-    logger.error "Please set the following switches in your vite.json instead: #{ unsupported }."
-    exit!
-  end
-
-  # Internal: Executes the command with the specified arguments.
-  def execute_command(args, capture: false)
-    if capture
-      capture3_with_output(*command_for(args), chdir: config.root)
-    else
-      Dir.chdir(config.root) { Kernel.exec(*command_for(args)) }
-    end
-  end
-
   # Internal: Returns an Array with the command to run.
   def command_for(args)
     [config.to_env].tap do |cmd|
+      args = args.clone
       cmd.append('node', '--inspect-brk') if args.delete('--inspect')
       cmd.append('node', '--trace-deprecation') if args.delete('--trace_deprecation')
       cmd.append(*vite_executable(cmd))

--- a/vite_ruby/lib/vite_ruby/runner.rb
+++ b/vite_ruby/lib/vite_ruby/runner.rb
@@ -4,6 +4,10 @@ require 'open3'
 
 # Public: Executes Vite commands, providing conveniences for debugging.
 class ViteRuby::Runner
+  def initialize(vite_ruby)
+    @vite_ruby = vite_ruby
+  end
+
   # Public: Executes Vite with the specified arguments.
   def run(argv, **options)
     $stdout.sync = true
@@ -13,6 +17,10 @@ class ViteRuby::Runner
 
 private
 
+  extend Forwardable
+
+  def_delegators :@vite_ruby, :config, :logger
+
   UNSUPPORTED_SWITCHES = %w[--host --port --https --root -r --config -c].freeze
 
   # Internal: Allows to prevent configuration mistakes by ensuring the Ruby app
@@ -20,38 +28,54 @@ private
   def detect_unsupported_switches!(args)
     return unless (unsupported = UNSUPPORTED_SWITCHES & args).any?
 
-    $stdout.puts "Please set the following switches in your vite.json instead: #{ unsupported }."
+    logger.error "Please set the following switches in your vite.json instead: #{ unsupported }."
     exit!
   end
 
   # Internal: Executes the command with the specified arguments.
   def execute_command(args, capture: false)
     if capture
-      Open3.capture3(*command_for(args), chdir: ViteRuby.config.root)
+      capture3_with_output(*command_for(args), chdir: config.root)
     else
-      Dir.chdir(ViteRuby.config.root) { Kernel.exec(*command_for(args)) }
+      Dir.chdir(config.root) { Kernel.exec(*command_for(args)) }
     end
   end
 
   # Internal: Returns an Array with the command to run.
   def command_for(args)
-    [vite_env].tap do |cmd|
-      cmd.append('node', '--inspect-brk') if args.include?('--debug')
+    [config.to_env].tap do |cmd|
+      cmd.append('node', '--inspect-brk') if args.delete('--inspect')
       cmd.append('node', '--trace-deprecation') if args.delete('--trace-deprecation')
       cmd.append(*vite_executable(cmd))
       cmd.append(*args)
-      cmd.append('--mode', ViteRuby.mode) unless args.include?('--mode') || args.include?('-m')
+      cmd.append('--mode', config.mode) unless args.include?('--mode') || args.include?('-m')
     end
-  end
-
-  # Internal: The environment variables to pass to the command.
-  def vite_env
-    ViteRuby.config.to_env
   end
 
   # Internal: Resolves to an executable for Vite.
   def vite_executable(cmd)
-    npx = cmd.include?('node') ? `which npx`.chomp("\n") : 'npx' rescue 'npx'
-    [npx, '--no-install', '--', 'vite']
+    cmd.include?('node') ? ['./node_modules/.bin/vite'] : ['npx', '--no-install', '--', 'vite']
+  end
+
+  # Internal: A modified version of capture3 that continuosly prints stdout.
+  # NOTE: This improves the experience of running bin/vite build.
+  def capture3_with_output(*cmd, **opts)
+    return Open3.capture3(*cmd, opts) if config.hide_build_console_output
+
+    Open3.popen3(*cmd, opts) { |_stdin, stdout, stderr, wait_threads|
+      out = Thread.new { read_lines(stdout) { |l| logger.info('vite') { l } } }
+      err = Thread.new { stderr.read }
+      [out.value, err.value, wait_threads.value]
+    }
+  end
+
+  # Internal: Reads and yield every line in the stream. Returns the full content.
+  def read_lines(io)
+    buffer = +''
+    while line = io.gets
+      buffer << line
+      yield line
+    end
+    buffer
   end
 end

--- a/vite_ruby/lib/vite_ruby/runner.rb
+++ b/vite_ruby/lib/vite_ruby/runner.rb
@@ -45,7 +45,7 @@ private
   def command_for(args)
     [config.to_env].tap do |cmd|
       cmd.append('node', '--inspect-brk') if args.delete('--inspect')
-      cmd.append('node', '--trace-deprecation') if args.delete('--trace-deprecation')
+      cmd.append('node', '--trace-deprecation') if args.delete('--trace_deprecation')
       cmd.append(*vite_executable(cmd))
       cmd.append(*args)
       cmd.append('--mode', config.mode) unless args.include?('--mode') || args.include?('-m')

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'm', '~> 1.5'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'minitest-reporters', '~> 1.4'
+  s.add_development_dependency 'minitest-stub_any_instance', '~> 1.0'
   s.add_development_dependency 'pry-byebug', '~> 3.9'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rubocop', '~> 1.9'


### PR DESCRIPTION
### Description 📖

This pull request groups together several changes to improve the UX when running the build command.

Each change is independent and is implemented in a separate commit, for future traceability.

### Improvements ✨ 

- Keep track of last build's result and timestamp which enables better error messages for missing entries.
- Now it's possible to run `bin/vite build --inspect` to start a debugging session.
- Now it's possible to run `bin/vite build --force` to build even if files haven't changed.
- Output from `vite build` is now streamed instead of printed when the command ends, providing better feedback.
- Added a mutex in the manifest to avoid multi-threaded servers from unnecessarily triggering several builds in certain (uncommon) situations when using auto-build.

### Screenshots 📷 

#### Error when build failed
<img width="400" alt="Screen Shot 2021-03-07 at 12 18 21 build failed" src="https://user-images.githubusercontent.com/1158253/110250622-06564280-7f5b-11eb-83a5-60bc21f5f976.png">

#### Error when build was successful and auto-build is enabled
<img width="400" alt="Screen Shot 2021-03-07 at 12 29 59 auto build enabled" src="https://user-images.githubusercontent.com/1158253/110250625-09513300-7f5b-11eb-8edf-f5a99ac86ed9.png">

#### Error when build was successful and auto-build is disabled
<img width="400" alt="Screen Shot 2021-03-07 at 12 34 04 default" src="https://user-images.githubusercontent.com/1158253/110250626-09e9c980-7f5b-11eb-8546-143a87f66bec.png">

