### PR TITLE
fix: handle getaddrinfo errors when checking dev server

### DIFF
--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -94,7 +94,7 @@ class ViteRuby
     Socket.tcp(config.host, config.port, connect_timeout: config.dev_server_connect_timeout).close
     @running_at = Time.now
     true
-  rescue SystemCallError
+  rescue
     @running_at = false
   end
 


### PR DESCRIPTION
### Description 📖

Fixes `#dev_server_running?` failing with an exception in case hostname is not resolveable.

### Background 📜

That's, for example, the case when using a dockerized development environment (and not running a vite-dev server at all).

### The Fix 🔨

I suggest removing the exception class filter altogether like [Webpacker does](https://github.com/rails/webpacker/blob/da362b8c96a4be5a4af8f8ad886f5dd8451f457f/lib/webpacker/dev_server.rb#L21).

### Screenshots 📷

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/1516722/111785757-0e54a180-88ce-11eb-8a33-7f85097f5006.png">
