### PR TITLE
fix: Preserve custom server.https configuration (close #42)

### DIFF
--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -34,8 +34,8 @@ const debug = createDebugger('vite-plugin-ruby:config')
 
 // Internal: Resolves the configuration from environment variables and a JSON
 // config file, and configures the entrypoints and manifest generation.
-function config (_viteConfig: UserConfig, env: ConfigEnv): UserConfig {
-  const config = loadConfiguration(env.mode, projectRoot)
+function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
+  const config = loadConfiguration(env.mode, projectRoot, userConfig)
   const { assetsDir, base, outDir, host, https, port, root } = config
 
   const entrypoints = Object.fromEntries(resolveEntrypointsForRollup(root!))

--- a/vite-plugin-ruby/src/types.ts
+++ b/vite-plugin-ruby/src/types.ts
@@ -1,3 +1,7 @@
+import type { ServerOptions } from 'vite'
+
+export type HttpsOption = ServerOptions['https']
+
 export interface Config {
   assetHost?: string
   assetsDir?: string
@@ -7,7 +11,7 @@ export interface Config {
   entrypointsDir?: string
   sourceCodeDir?: string
   host?: string
-  https?: boolean
+  https?: HttpsOption
   port?: number
   publicOutputDir?: string
   watchAdditionalPaths?: string[]

--- a/vite-plugin-ruby/src/utils.ts
+++ b/vite-plugin-ruby/src/utils.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'fs'
 
 import { ENV_PREFIX } from './constants'
 
+import type { HttpsOption } from './types'
+
 // Internal: Returns true if the specified value is a plain JS object
 export function isObject (value: unknown): value is Record<string, any> {
   return Object.prototype.toString.call(value) === '[object Object]'
@@ -19,8 +21,10 @@ export function configOptionFromEnv (optionName: string) {
 }
 
 // Internal: Ensures it's easy to turn off a setting with env vars.
-export function booleanOption (value: string | boolean | undefined): boolean | undefined {
-  return value === true || value === 'true' || (value === undefined ? undefined : false)
+export function booleanOption (value: 'true' | 'false' | boolean | any): boolean | any {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return value
 }
 
 // Internal: Returns the filename without the extension.


### PR DESCRIPTION
### Description 📖

This pull request fixes an issue where a [`server.https`](https://vitejs.dev/config/#server-https) option provided by the user in `vite.config.ts` was being overriden by the values in `config/vite.json`.

While it's important to set `"https": true` in `config/vite.json` to ensure the rack proxy doesn't [disable `https`](https://github.com/ElMassimo/vite_ruby/blob/fix/https/vite_ruby/lib/vite_ruby/dev_server_proxy.rb#L47), options provided by the user should be preserved.