### PR TITLE
fix: Stream output during installation and don't skip installation of npm packages when no lockfile is detected

### DIFF
--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -100,6 +100,6 @@ private
 
   def stub_runner(success:, &block)
     args = [:sterr, :stdout, OpenStruct.new(success?: success)]
-    ViteRuby::Runner.stub_any_instance(:capture3_with_output, args, &block)
+    ViteRuby::IO.stub(:capture, args, &block)
   end
 end

--- a/test/engine_rake_tasks_test.rb
+++ b/test/engine_rake_tasks_test.rb
@@ -62,10 +62,10 @@ class EngineRakeTasksTest < ViteRuby::Test
       ViteRuby::CLI::Install.new.call
       ViteRuby.commands.verify_install
       ViteRuby::CLI::Version.new.call
-      stub_runner('build', capture: true) {
+      stub_runner('build') {
         assert ViteRuby::CLI::Build.new.call(mode: ViteRuby.mode)
       }
-      stub_runner('--wat') {
+      stub_runner('--wat', exec: true) {
         assert ViteRuby::CLI::Dev.new.call(mode: ViteRuby.mode, args: ['--wat'])
       }
       ViteRuby::CLI::Clobber.new.call(mode: ViteRuby.mode)

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -23,7 +23,7 @@ class RunnerTest < ViteRuby::Test
 
   def test_command_capture
     ViteRuby::Runner.stub_any_instance(:vite_executable, 'echo') {
-      stdout, stderr, status = ViteRuby.run(['"Hello"'], capture: true)
+      stdout, stderr, status = ViteRuby.run(['"Hello"'])
       assert_equal %("Hello" --mode production\n), stdout
       assert_equal '', stderr
       assert status.success?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,7 +70,7 @@ private
     Dir.chdir(test_app_path) {
       mock = Minitest::Mock.new
       mock.expect(:call, nil, [ViteRuby.config.to_env, %r{node_modules/.bin/vite}, *argv, *flags])
-      Kernel.stub(:exec, mock) { ViteRuby.run(argv) }
+      Kernel.stub(:exec, mock) { ViteRuby.run(argv, exec: true) }
       mock.verify
     }
   end

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -10,6 +10,7 @@ loader.ignore("#{ __dir__ }/install")
 loader.ignore("#{ __dir__ }/tasks")
 loader.ignore("#{ __dir__ }/exe")
 loader.inflector.inflect('cli' => 'CLI')
+loader.inflector.inflect('io' => 'IO')
 loader.setup
 
 class ViteRuby

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -69,7 +69,7 @@ private
   def build_with_vite(*args)
     logger.info 'Building with Vite ⚡️'
 
-    stdout, stderr, status = ViteRuby.run(['build', *args], capture: true)
+    stdout, stderr, status = ViteRuby.run(['build', *args])
     log_build_result(stdout, stderr.to_s, status)
 
     status.success?

--- a/vite_ruby/lib/vite_ruby/cli/dev.rb
+++ b/vite_ruby/lib/vite_ruby/cli/dev.rb
@@ -8,6 +8,6 @@ class ViteRuby::CLI::Dev < ViteRuby::CLI::Build
   option(:force, desc: 'Force Vite to re-bundle dependencies', type: :boolean)
 
   def call(**options)
-    super { |args| ViteRuby.run(args) }
+    super { |args| ViteRuby.run(args, exec: true) }
   end
 end

--- a/vite_ruby/lib/vite_ruby/io.rb
+++ b/vite_ruby/lib/vite_ruby/io.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+# Public: Builds on top of Ruby I/O open3 providing a friendlier experience.
+module ViteRuby::IO
+  class << self
+    # Internal: A modified version of capture3 that can continuosly print stdout.
+    # NOTE: Streaming output provides a better UX when running bin/vite build.
+    def capture(*cmd, with_output: $stdout.method(:puts), stdin_data: '', **opts)
+      return Open3.capture3(*cmd, **opts) unless with_output
+
+      Open3.popen3(*cmd, **opts) { |stdin, stdout, stderr, wait_threads|
+        stdin << stdin_data
+        stdin.close
+        out = Thread.new { read_lines(stdout, &with_output) }
+        err = Thread.new { stderr.read }
+        [out.value, err.value, wait_threads.value]
+      }
+    end
+
+    # Internal: Reads and yield every line in the stream. Returns the full content.
+    def read_lines(io)
+      buffer = +''
+      while line = io.gets
+        buffer << line
+        yield line
+      end
+      buffer
+    end
+  end
+end


### PR DESCRIPTION
### Description 📖

This pull request addresses a minor UX issue mentioned in https://github.com/ElMassimo/vite_ruby/discussions/72, where running `vite install` on a project without a JS lockfile will fail to install dependencies.

As a result of this change, when no lockfile is present it will now default to `npm` (or the user's [preferred package manager](https://github.com/antfu/ni#config)) and proceed to install the dependencies.

#### Streamed Output 📜

Prior to this change, the output of running `npm install` or `yarn install` was being captured—in cases where the installation takes a long time, it was reasonable for a user to think the command had hung.

After this change, the output will be streamed line by line, which is a nicer experience.

### Note ✏️ 

Although `ni` supports an interactive prompt when lockfile detection fails, piping the input correctly through stdin requires more logic than I'm willing to support for this very niche use case. Hence the decision to pass `"\n"` and let it pick `npm` instead.