### PR TITLE
Ruby 2.4

### DIFF
--- a/vite_rails_legacy/vite_rails_legacy.gemspec
+++ b/vite_rails_legacy/vite_rails_legacy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/ElMassimo/vite_ruby/blob/vite_rails_legacy@#{ ViteRailsLegacy::VERSION }/vite_rails_legacy/CHANGELOG.md",
   }
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.5')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.4')
 
   s.add_dependency 'railties', '< 5'
   s.add_dependency 'vite_ruby', '~> 1.0'

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'backports/2.5.0/hash/transform_keys'
 
 require 'logger'
 require 'forwardable'

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'backports/2.5.0/hash/transform_keys'
+require 'backports/2.5.0/array/append'
 
 require 'logger'
 require 'forwardable'

--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -102,10 +102,14 @@ private
 
     # Internal: Used to load a JSON file from the specified path.
     def load_json(path)
-      JSON.parse(File.read(File.expand_path(path))).each do |_env, config|
-        config.transform_keys!(&SNAKE_CASE) if config.is_a?(Hash)
-      end.tap do |config|
-        config.transform_keys!(&SNAKE_CASE)
+      JSON.parse(File.read(File.expand_path(path))).map do |env, config|
+        if config.is_a?(Hash)
+          [env, config.transform_keys(&SNAKE_CASE)]
+        else
+          [env, config]
+        end
+      end.to_h.tap do |config|
+        config.transform_keys(&SNAKE_CASE)
       end
     end
 

--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -108,9 +108,7 @@ private
         else
           [env, config]
         end
-      end.to_h.tap do |config|
-        config.transform_keys(&SNAKE_CASE)
-      end
+      end.to_h.transform_keys(&SNAKE_CASE)
     end
 
     # Internal: Retrieves a configuration option from environment variables.

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'dry-cli', '~> 0.6'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'
   s.add_dependency 'zeitwerk', '~> 2.2'
-  s.add_dependency 'backports', '~> 3.21'
+  s.add_dependency 'backports', '~> 3.20'
 
   s.add_development_dependency 'm', '~> 1.5'
   s.add_development_dependency 'minitest', '~> 5.0'

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/ElMassimo/vite_ruby/blob/vite_ruby@#{ ViteRuby::VERSION }/vite_ruby/CHANGELOG.md",
   }
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.5')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.4')
 
   s.add_dependency 'dry-cli', '~> 0.6'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'dry-cli', '~> 0.6'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'
   s.add_dependency 'zeitwerk', '~> 2.2'
+  s.add_dependency 'backports', '~> 3.21'
 
   s.add_development_dependency 'm', '~> 1.5'
   s.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
### Description 📖

This pull request allows vite ruby to be used with Ruby 2.4 by pulling in some backports. It's a small change. I have used my fork of Vite Ruby to work on a legacy app on Ruby 2.4.

### Background 📜

This was happening because `Hash#transform_keys` and `Array#append` are being used by Vite Ruby but 2.4 does not support these yet.


