### PR TITLE
Force skipping vite dev server

### DIFF
--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -45,7 +45,11 @@ module ViteRails::TagHelpers
 
   # Public: Renders a <link> tag for the specified Vite entrypoints.
   def vite_stylesheet_tag(*names, **options)
-    style_paths = names.map { |name| vite_asset_path(name, type: :stylesheet) }
+    force_build = options.delete(:force_build)
+    style_paths = names.map { |name| vite_asset_path(name, type: :stylesheet, force_build: force_build) }
+    if force_build
+      style_paths.map! { |path| path + "?force_build=true" }
+    end
     stylesheet_link_tag(*style_paths, **options)
   end
 

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -50,6 +50,8 @@ private
 
   def vite_should_handle?(env)
     path, query, referer = env['PATH_INFO'], env['QUERY_STRING'], env['HTTP_REFERER']
+    return false if query&.include?('force_build=true')
+
     return true if path.start_with?(vite_asset_url_prefix) # Vite asset
     return true if path.start_with?(VITE_DEPENDENCY_PREFIX) # Packages and imports
     return true if query&.start_with?('t=') # Hot Reload for a stylesheet

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -77,10 +77,10 @@ protected
   # Example:
   #   manifest.lookup('calendar.js')
   #   => { "file" => "/vite/assets/calendar-1016838bab065ae1e122.js", "imports" => [] }
-  def lookup(name, type: nil)
-    @build_mutex.synchronize { builder.build } if should_build?
+  def lookup(name, type: nil, force_build: false)
+    @build_mutex.synchronize { builder.build } if force_build || should_build?
 
-    find_manifest_entry(with_file_extension(name, type))
+    find_manifest_entry(with_file_extension(name, type), force_build: force_build)
   end
 
 private
@@ -96,8 +96,8 @@ private
   end
 
   # Internal: Finds the specified entry in the manifest.
-  def find_manifest_entry(name)
-    if dev_server_running?
+  def find_manifest_entry(name, force_build: false)
+    if dev_server_running? && !force_build
       { 'file' => prefix_vite_asset(name.to_s) }
     else
       manifest[name.to_s]


### PR DESCRIPTION
Hi ! Thanks for the great work with vite_ruby ⚡ 

I was looking into integrating it into my app but got blocked because of [premailer](https://github.com/premailer/premailer/)

Premailer needs to read and parse a CSS file to be able to inline it properly. Obviously it doesn't work when the dev server is enabled as it expects a classic css file and not ESM.

**This PR is a total draft / POC**, it aims at being able to skip the vite server, and grab a compiled file when we want to, basically force the on demand behaviour even when the dev server is running.

The wording is very bad, `force_build` isn't correct and should be changed if this goes further than this draft.

I just wanted to get your opinion on this, do you see this as something that could make its way into the codebase (if re-done properly obviously), are there any gotchas I didn't see ? 

Here is what I had to do : 
- Add an option to "force a build", which is rather a "force skip the dev server"
- In the dev server proxy, don't forward to the dev server thanks to a URL param

Thanks !
