### PR TITLE
fix: use asset host if set during development

### DIFF
--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -93,6 +93,14 @@ class ManifestTest < ViteRuby::Test
     }
   end
 
+  def test_lookup_success_with_asset_host_and_dev_server
+    entry = { 'file' => 'http://example.com/vite-production/application.js' }
+    refresh_config(asset_host: 'http://example.com')
+    with_dev_server_running {
+      assert_equal entry, lookup!('application.js')
+    }
+  end
+
   def test_lookup_nil
     assert_nil lookup('foo.js')
   end

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -122,7 +122,7 @@ private
 
   # Internal: Scopes an asset to the output folder in public, as a path.
   def prefix_vite_asset(path)
-    File.join("/#{ config.public_output_dir }", path)
+    File.join(config.asset_host || '/', config.public_output_dir, path)
   end
 
   # Internal: Resolves the paths that reference a manifest entry.


### PR DESCRIPTION
### Description 📖

This pull request fixes the loading of the Vite client and react refresh preamble when an `asset_host` is defined and the dev server is running.


### Background 📜

This was happening because when an asset host is defined and a dev server is running the vite client is loaded twice. Once with the `asset_host` domain and once with the relative path (so the current domain).

Consider the case where all assets are provided by `my-cdn.com`. The Vite client loaded with the `vite_client_tag` tag will be loaded without any subdomain (`/vite-dev/@vite/client`) while the client as fetched from within the code will be loaded from the same domain as the asset itself (in this case `my-cdn.com/vite-dev/@vite/client`).

This results in two vite clients being loaded and a crashing page.

### The Fix 🔨

By changing the prefixing method of the vite assets with the assets subdomain.

### Screenshots 📷
