### PR TITLE
Configure vite HMR host from vite.json development.host

### DIFF
--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -36,7 +36,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const { assetsDir, base, outDir, host, https, port, root, entrypoints } = config
 
   const fs = { allow: [projectRoot], strict: true }
-  const hmr = { host, port }
+  const hmr = userConfig.server?.hmr ?? { host, port }
   const server = { host, https, port, strictPort: true, fs, hmr }
 
   const build = {

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -36,7 +36,8 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const { assetsDir, base, outDir, host, https, port, root, entrypoints } = config
 
   const fs = { allow: [projectRoot], strict: true }
-  const server = { host, https, port, strictPort: true, fs }
+  const hmr = { host, port }
+  const server = { host, https, port, strictPort: true, fs, hmr }
 
   const build = {
     emptyOutDir: true,


### PR DESCRIPTION
### Description 📖

Adjust vite configuration to set HMR host and port.

### Background 📜

When running an app that uses multiple subdomains, I was running into an issue where I wanted to run vite listening on localhost, and having app loaded from sub1.app.test and sub2.app.test use vite HMR at localhost:3036. I configured development.host in vite.json which correctly set `ViteRuby.config.host_with_port` to `localhost:3036`, but vite client in the browser was trying to connect to `sub1.app.test:3036`, violating CSP.

### The Fix 🔨

This change configures the vite client to use the same HMR config as what we're setting on the server side.

### Screenshots 📷
