### PR TITLE
fix: add variable declaration to import.meta.globEager (close #154)

### DIFF
--- a/vite_rails/templates/entrypoints/application.js
+++ b/vite_rails/templates/entrypoints/application.js
@@ -21,7 +21,7 @@ console.log('Visit the guide for more information: ', 'https://vite-ruby.netlify
 // import ActiveStorage from '@rails/activestorage'
 //
 // // Import all channels.
-// import.meta.globEager('./**/*_channel.js')
+const _channels = import.meta.globEager('./**/*_channel.js')
 //
 // Turbolinks.start()
 // ActiveStorage.start()


### PR DESCRIPTION
### Description 📖, Background 📜, The Fix 🔨

Fixes #154. It adds variable declaration to `import.meta.globEager`, as it seems that `Vite.js` doesn't support `import.meta.globEager` calls without saving them somewhere.
