### PR TITLE
fix: handle new virtual legacy-polyfill name

### DIFF
--- a/test/test_app/public/vite-production/manifest.json
+++ b/test/test_app/public/vite-production/manifest.json
@@ -41,7 +41,7 @@
   "_log.d31acc25-legacy.js": {
     "file": "assets/log.d31acc25-legacy.js"
   },
-  "../../vite/legacy-polyfills": {
+  "../../\u0000vite/legacy-polyfills": {
     "file": "assets/polyfills-legacy.07477394.js",
     "src": "../../vite/legacy-polyfills",
     "isEntry": true

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -147,9 +147,11 @@ private
 
   # Internal: Resolves the manifest entry name for the specified resource.
   def resolve_entry_name(name, type: nil)
-    name = with_file_extension(name.to_s, type)
+    unless name.include?('legacy-polyfills')
+      name = with_file_extension(name.to_s, type)
 
-    raise ArgumentError, "Asset names can not be relative. Found: #{ name }" if name.start_with?('.') && !name.include?('legacy-polyfills')
+      raise ArgumentError, "Asset names can not be relative. Found: #{ name }" if name.start_with?('.')
+    end
 
     # Explicit path, relative to the source_code_dir.
     name.sub(%r{^~/(.+)$}) { return Regexp.last_match(1) }


### PR DESCRIPTION
### Description 📖

This pull request ensures that the new polyfill name with the `\u0000` character is handled as expected.

### Background 📜

This was happening because the entry of the legacy-polyfill name has changed to start with a `\u0000` character to mark it as a virtual entry in vite 2.7.


### The Fix 🔨

By changing the lookup to not try to parse the entry name, the `\u0000` character is ignored.

Closes #156 

### Screenshots 📷
