### PR TITLE
Add #vite_image_tag to ViteRails::TagHelpers

### DIFF
--- a/docs/guide/rails.md
+++ b/docs/guide/rails.md
@@ -62,16 +62,16 @@ If using `.jsx` or any pre-processor, make sure to be explicit:
 <%= vite_stylesheet_tag 'theme.scss' %>
 ```
 
-For images you can use <kbd>[vite_image_tag][helpers]</kbd>:
+For images you can use <kbd>vite_image_tag</kbd>:
+
 ```erb
-# Assuming an image path of app/frontend/images/logo.jpg
 <%= vite_image_tag 'images/logo.jpg' %>
 ```
 
-For other types of assets, you can just use <kbd>[vite_asset_path][helpers]</kbd> and pass the resulting URI to the appropriate tag helper.
+For other types of assets, you can use <kbd>[vite_asset_path][helpers]</kbd> and pass the resulting URI to the appropriate tag helper.
 
 ```erb
-<img src="<%= vite_asset_path 'images/logo.svg' %>" />
+<link rel="apple-touch-icon" type="image/png" href="<%= vite_asset_path 'images/favicon.png' %>" />
 <link rel="prefetch" href="<%= vite_asset_path 'typography.css' %>" />
 ```
 

--- a/docs/guide/rails.md
+++ b/docs/guide/rails.md
@@ -62,8 +62,13 @@ If using `.jsx` or any pre-processor, make sure to be explicit:
 <%= vite_stylesheet_tag 'theme.scss' %>
 ```
 
+For images you can use <kbd>[vite_image_tag][helpers]</kbd>:
+```erb
+# Assuming an image path of app/frontend/images/logo.jpg
+<%= vite_image_tag 'images/logo.jpg' %>
+```
 
-For other types of assets, you can use <kbd>[vite_asset_path][helpers]</kbd> and pass the resulting URI to the appropriate tag helper.
+For other types of assets, you can just use <kbd>[vite_asset_path][helpers]</kbd> and pass the resulting URI to the appropriate tag helper.
 
 ```erb
 <img src="<%= vite_asset_path 'images/logo.svg' %>" />

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -132,17 +132,17 @@ class HelperTest < HelperTestCase
   end
 
   def test_vite_image_tag
-    assert_equal %(<img class="test" src="/vite-production/images/tag.as8d7a98.jpg" />),
-      vite_image_tag('images/tag.jpg', class: 'test')
+    assert_equal %(<img class="test" alt="Logo" src="/vite-production/assets/logo.f42fb7ea.png" />),
+      vite_image_tag('images/logo.png', class: 'test', alt: 'Logo')
 
-    assert_equal %(<img srcset="/vite-production/images/tag-2x.bs8d7a77.jpg 2x" src="/vite-production/images/tag.as8d7a98.jpg" />),
-      vite_image_tag('images/tag.jpg', srcset: { 'images/tag-2x.jpg' => '2x' })
+    assert_equal %(<img srcset="/vite-production/assets/logo-2x.bs8d7a77.png 2x" alt="Logo" src="/vite-production/assets/logo.f42fb7ea.png" />),
+      vite_image_tag('images/logo.png', srcset: { 'images/logo-2x.png' => '2x' }, alt: 'Logo')
 
     with_dev_server_running {
-      assert_equal %(<img src="/vite-dev/images/tag.jpg" />), vite_image_tag('images/tag.jpg')
+      assert_equal %(<img alt="Logo" src="/vite-dev/images/logo.png" />), vite_image_tag('images/logo.png', alt: 'Logo')
 
-      assert_equal %(<img srcset="/vite-dev/images/tag-2x.jpg 2x" src="/vite-dev/images/tag.jpg" />),
-        vite_image_tag('images/tag.jpg', srcset: { 'images/tag-2x.jpg' => '2x' })
+      assert_equal %(<img srcset="/vite-dev/images/logo-2x.png 2x" alt="Logo" src="/vite-dev/images/logo.png" />),
+        vite_image_tag('images/logo.png', srcset: { 'images/logo-2x.png' => '2x' }, alt: 'Logo')
     }
   end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -130,4 +130,19 @@ class HelperTest < HelperTestCase
       HTML
     }
   end
+
+  def test_vite_image_tag
+    assert_equal %(<img class="test" src="/vite-production/images/tag.as8d7a98.jpg" />),
+      vite_image_tag('images/tag.jpg', class: 'test')
+
+    assert_equal %(<img srcset="/vite-production/images/tag-2x.bs8d7a77.jpg 2x" src="/vite-production/images/tag.as8d7a98.jpg" />),
+      vite_image_tag('images/tag.jpg', srcset: { 'images/tag-2x.jpg' => '2x' })
+
+    with_dev_server_running {
+      assert_equal %(<img src="/vite-dev/images/tag.jpg" />), vite_image_tag('images/tag.jpg')
+
+      assert_equal %(<img srcset="/vite-dev/images/tag-2x.jpg 2x" src="/vite-dev/images/tag.jpg" />),
+        vite_image_tag('images/tag.jpg', srcset: { 'images/tag-2x.jpg' => '2x' })
+    }
+  end
 end

--- a/test/test_app/public/vite-production/manifest-assets.json
+++ b/test/test_app/public/vite-production/manifest-assets.json
@@ -15,6 +15,10 @@
     "file": "assets/logo.f42fb7ea.png",
     "src": "images/logo.png"
   },
+  "images/logo-2x.png": {
+    "file": "assets/logo-2x.bs8d7a77.png",
+    "src": "images/logo-2x.png"
+  },
   "images/logo.svg": {
     "file": "assets/logo.322aae0c.svg",
     "src": "images/logo.svg"

--- a/test/test_app/public/vite-production/manifest.json
+++ b/test/test_app/public/vite-production/manifest.json
@@ -99,5 +99,13 @@
   },
   "_log.818edfb8.js": {
     "file": "assets/log.818edfb8.js"
+  },
+  "images/tag.jpg": {
+    "file": "images/tag.as8d7a98.jpg",
+    "src": "images/tag.jpg"
+  },
+  "images/tag-2x.jpg": {
+    "file": "images/tag-2x.bs8d7a77.jpg",
+    "src": "images/tag-2x.jpg"
   }
 }

--- a/test/test_app/public/vite-production/manifest.json
+++ b/test/test_app/public/vite-production/manifest.json
@@ -99,13 +99,5 @@
   },
   "_log.818edfb8.js": {
     "file": "assets/log.818edfb8.js"
-  },
-  "images/tag.jpg": {
-    "file": "images/tag.as8d7a98.jpg",
-    "src": "images/tag.jpg"
-  },
-  "images/tag-2x.jpg": {
-    "file": "images/tag-2x.bs8d7a77.jpg",
-    "src": "images/tag-2x.jpg"
   }
 }

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -49,6 +49,17 @@ module ViteRails::TagHelpers
     stylesheet_link_tag(*style_paths, **options)
   end
 
+  # Public: Renders an <img> tag for the specified Vite asset.
+  def vite_image_tag(name, **options)
+    if options[:srcset] && !options[:srcset].is_a?(String)
+      options[:srcset] = options[:srcset].map do |src_name, size|
+        "#{ vite_asset_path(src_name) } #{ size }"
+      end.join(', ')
+    end
+
+    image_tag(vite_asset_path(name), options)
+  end
+
 private
 
   # Internal: Returns the current manifest loaded by Vite Ruby.

--- a/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
@@ -49,6 +49,17 @@ module ViteRailsLegacy::TagHelpers
     stylesheet_link_tag(*style_paths, **options)
   end
 
+  # Public: Renders an <img> tag for the specified Vite asset.
+  def vite_image_tag(name, **options)
+    if options[:srcset] && !options[:srcset].is_a?(String)
+      options[:srcset] = options[:srcset].map do |src_name, size|
+        "#{ vite_asset_path(src_name) } #{ size }"
+      end.join(', ')
+    end
+
+    image_tag(vite_asset_path(name), options)
+  end
+
 private
 
   # Internal: Returns the current manifest loaded by Vite Ruby.


### PR DESCRIPTION
### Description 📖

Adds a new `vite_image_tag` helper for `vite_rails`. 

### Background 📜

Reduces boilerplate a little bit and makes it slightly easier when switching from Webpacker to Vite (replacing `image_pack_tag`).

Discussion here: https://github.com/ElMassimo/vite_ruby/discussions/108#discussioncomment-1858112

### The Fix 🔨

Added a new helper to `ViteRails::TagHelpers`

### Screenshots 📷
