### PR TITLE
fix: allow providing an empty public output dir (close #161)

### DIFF
--- a/test/dev_server_proxy_test.rb
+++ b/test/dev_server_proxy_test.rb
@@ -90,6 +90,18 @@ class DevServerProxyTest < ViteRuby::Test
     assert_not_forwarded
   end
 
+  def test_empty_public_output_dir
+    refresh_config(public_output_dir: '')
+    get_with_dev_server_running '/'
+    assert_not_forwarded
+
+    get_with_dev_server_running '/entrypoints/application.js'
+    assert_forwarded to: '/entrypoints/application.js'
+
+    get_with_dev_server_running '/entrypoints/sassy.scss.css'
+    assert_forwarded to: '/entrypoints/sassy.scss'
+  end
+
 private
 
   def get_with_dev_server_running(*args)

--- a/test/test_app/app/frontend/entrypoints/sassy.scss
+++ b/test/test_app/app/frontend/entrypoints/sassy.scss
@@ -1,0 +1,3 @@
+.colored {
+  color: red;
+}

--- a/vite-plugin-ruby/src/config.ts
+++ b/vite-plugin-ruby/src/config.ts
@@ -101,7 +101,7 @@ function coerceConfigurationValues (config: ResolvedConfig, projectRoot: string,
   // Add the asset host to enable usage of a CDN.
   const assetHost = config.assetHost || ''
   const assetHostWithProtocol = assetHost && !assetHost.startsWith('http') ? `//${assetHost}` : assetHost
-  const base = `${assetHostWithProtocol || config.base}/${config.publicOutputDir}/`
+  const base = slash(join(assetHostWithProtocol || config.base || '/', config.publicOutputDir, '/'))
 
   const entrypoints = resolveEntrypointFiles(projectRoot, root, config)
   return { ...config, root, outDir, base, entrypoints }

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -61,6 +61,6 @@ private
   end
 
   def vite_asset_url_prefix
-    @vite_asset_url_prefix ||= config.public_output_dir.empty? ? '/' : "/#{ config.public_output_dir }/"
+    @vite_asset_url_prefix ||= config.public_output_dir.empty? ? 'NEVER' : "/#{ config.public_output_dir }/"
   end
 end

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -61,6 +61,6 @@ private
   end
 
   def vite_asset_url_prefix
-    @vite_asset_url_prefix ||= "/#{ config.public_output_dir }/"
+    @vite_asset_url_prefix ||= config.public_output_dir.empty? ? '/' : "/#{ config.public_output_dir }/"
   end
 end

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -31,10 +31,14 @@ private
 
   def rewrite_uri_for_vite(env)
     uri = env.fetch('REQUEST_URI') { [env['PATH_INFO'], env['QUERY_STRING']].reject { |str| str.to_s.strip.empty? }.join('?') }
+    env['PATH_INFO'], env['QUERY_STRING'] = (env['REQUEST_URI'] = normalize_uri(uri)).split('?')
+  end
+
+  def normalize_uri(uri)
+    uri
       .sub(HOST_WITH_PORT_REGEX, '/') # Hanami adds the host and port.
       .sub('.ts.js', '.ts') # Hanami's javascript helper always adds the extension.
       .sub(/(\.(?!min|module)\w+)\.css$/, '\1') # Rails' stylesheet_link_tag always adds the extension.
-    env['PATH_INFO'], env['QUERY_STRING'] = (env['REQUEST_URI'] = uri).split('?')
   end
 
   def forward_to_vite_dev_server(env)
@@ -49,7 +53,7 @@ private
   end
 
   def vite_should_handle?(env)
-    path = env['PATH_INFO']
+    path = normalize_uri(env['PATH_INFO'])
     return true if path.start_with?(vite_asset_url_prefix) # Vite asset
     return true if path.start_with?(VITE_DEPENDENCY_PREFIX) # Packages and imports
     return true if file_in_vite_root?(path) # Fallback if Vite can serve the file
@@ -61,6 +65,6 @@ private
   end
 
   def vite_asset_url_prefix
-    @vite_asset_url_prefix ||= config.public_output_dir.empty? ? 'NEVER' : "/#{ config.public_output_dir }/"
+    @vite_asset_url_prefix ||= config.public_output_dir.empty? ? "\0" : "/#{ config.public_output_dir }/"
   end
 end


### PR DESCRIPTION
### Description 📖

This pull request adds support for providing an empty `publicOutputDir`.

### Background 📜

For a while, the dev server proxy relied on `publicOutputDir` as a "prefix" to [detect requests](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/dev_server_proxy.rb#L53) for the Vite dev server.

Now that Vite has patched bugs related to HMR requests, the proxy can rely on [file existence](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/dev_server_proxy.rb#L55).

### The Fix 🔨

Avoid adding slashes manually, or rely on `join` from the Node standard library.