### PR TITLE
Add style-src to suggestion Content Security Policy changes

### DIFF
--- a/examples/hanami_bookshelf/apps/web/application.rb
+++ b/examples/hanami_bookshelf/apps/web/application.rb
@@ -270,7 +270,8 @@ module Web
       security.content_security_policy(
         security.content_security_policy
           .sub('script-src', "script-src 'unsafe-eval'")
-          .sub('connect-src', "connect-src ws://#{ ViteRuby.config.host_with_port }"),
+          .sub('connect-src', "connect-src ws://#{ ViteRuby.config.host_with_port }")
+          .sub('style-src', "style-src 'unsafe-inline'"),
       )
       # Don't handle exceptions, render the stack trace
       handle_exceptions false

--- a/vite_hanami/lib/vite_hanami/installation.rb
+++ b/vite_hanami/lib/vite_hanami/installation.rb
@@ -18,6 +18,7 @@ module ViteHanami::Installation
         security.content_security_policy
           .sub('script-src', "script-src 'unsafe-eval' 'unsafe-inline'")
           .sub('connect-src', "connect-src ws://\#{ ViteRuby.config.host_with_port }")
+          .sub('style-src', "style-src 'unsafe-inline'")
       )
     CSP
     append root.join('Rakefile'), <<~RAKE

--- a/vite_rails/lib/vite_rails/installation.rb
+++ b/vite_rails/lib/vite_rails/installation.rb
@@ -30,8 +30,12 @@ module ViteRails::Installation
       #    policy.connect_src *policy.connect_src, "ws://\#{ ViteRuby.config.host_with_port }" if Rails.env.development?
     CSP
     inject_line_after csp_file, 'policy.script_src', <<~CSP
-          # Allow @vite/client to hot reload changes in development
+          # Allow @vite/client to hot reload javascript changes in development
       #    policy.script_src *policy.script_src, :unsafe_eval, "http://\#{ ViteRuby.config.host_with_port }" if Rails.env.development?
+    CSP
+    inject_line_after csp_file, 'policy.style_src', <<~CSP
+          # Allow @vite/client to hot reload style changes in development
+      #    policy.style_src *policy.style_src, :unsafe_inline if Rails.env.development?
     CSP
   end
 


### PR DESCRIPTION
### Description 📖

Add style-src suggestion to content security policy so JS injected styles work in development

### Background 📜

Without this, styles injected via JS into a <style type="text/css"> tag won't work

### The Fix 🔨

By adding style-src, styles added this way in development 