### PR TITLE
fix(vite-plugin-ruby): regression in assetHosts protocol

### DIFF
--- a/vite-plugin-ruby/src/config.ts
+++ b/vite-plugin-ruby/src/config.ts
@@ -101,7 +101,9 @@ function coerceConfigurationValues (config: ResolvedConfig, projectRoot: string,
   // Add the asset host to enable usage of a CDN.
   const assetHost = config.assetHost || ''
   const assetHostWithProtocol = assetHost && !assetHost.startsWith('http') ? `//${assetHost}` : assetHost
-  const base = slash(join(assetHostWithProtocol || config.base || '/', config.publicOutputDir, '/'))
+  const host = assetHostWithProtocol || config.base || ''
+  const suffix = config.publicOutputDir ? `${slash(config.publicOutputDir)}/` : ''
+  const base = `${host}/${suffix}`
 
   const entrypoints = resolveEntrypointFiles(projectRoot, root, config)
   return { ...config, root, outDir, base, entrypoints }


### PR DESCRIPTION
### Description 📖

Currently if the asset hosts contains a protocol (https://my-cdn.org for example),
the path.join method from node will replace the double forward slash with a single
one. Therefore the final base URL will become something like:

```
  https:/my-cdn.org/vite
```

This gives problems if vite has to resolve URLs itself. For example if you have:

```
  body {
    background-image: url('../background.png')
  }
```

will resolve in:

```
  body { background-image: url('https:/my-cdn.org/vite/background.png') }
```

which in its turn will call this as a relative path.

### Background 📜

See above

### The Fix 🔨

The fix removes the path.join method with a simple interpolated string.

### Screenshots 📷
