### PR TITLE
Remove user-specific entries added to .gitignore

### DIFF
--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -95,6 +95,8 @@ private
       /public/vite-dev
       /public/vite-test
       node_modules
+      # Vite uses dotenv and suggests to ignore local-only env files. See
+      # https://vitejs.dev/guide/env-and-mode.html#env-files
       *.local
     GITIGNORE
   end

--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -96,7 +96,6 @@ private
       /public/vite-test
       node_modules
       *.local
-      .DS_Store
     GITIGNORE
   end
 


### PR DESCRIPTION
It removes the `.DS_Store` entry inserted by vite_ruby into `.gitignore`, as it is user-specific and should be added to user's global gitignore.

