### PR TITLE
feat: allow setting emptyOutDir config and set it to false in production mode (#177)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -207,6 +207,15 @@ You can customize this behavior using the following options.
 
   Specify the directory where the [entrypoints] will be located (relative to <kbd>[sourceCodeDir]</kbd>).
 
+### emptyOutDir
+
+- **Default:** `env !== 'production'`
+- **Env Var:** `VITE_RUBY_EMPTY_OUT_DIR`
+
+  During (production) builds, Vite can empty the previous asset-directory. If
+  you are using traditional Capistrano-like deployments on the same host, you
+  should set it to false or leave it at the default value to avoid downtime.
+
 ## Other Options
 
 ### additionalEntrypoints

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -39,7 +39,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const server = { host, https, port, strictPort: true, fs, hmr }
 
   const build = {
-    emptyOutDir: true,
+    emptyOutDir: userConfig.emptyOutDir ?? config.mode !== 'production',
     sourcemap: config.mode === 'production',
     ...userConfig.build,
     assetsDir,


### PR DESCRIPTION
See #177 - assets been deleted between deployments.

Not sure, if there any other places to edit. I guess the ENV variables are populated automatically and transformed to camelcase options?
