### PR TITLE
fix: don't add crossorigin to included stylesheet tags (close #189)

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -96,9 +96,9 @@ class HelperTest < HelperTestCase
       %(<link rel="modulepreload" href="/vite-production/assets/log.818edfb8.js" as="script" crossorigin="anonymous">),
       %(<link rel="modulepreload" href="/vite-production/assets/vue.3002ada6.js" as="script" crossorigin="anonymous">),
       %(<link rel="modulepreload" href="/vite-production/assets/vendor.0f7c0ec3.js" as="script" crossorigin="anonymous">),
-      link(href: '/vite-production/assets/app.517bf154.css', crossorigin: 'anonymous'),
-      link(href: '/vite-production/assets/theme.e6d9734b.css', crossorigin: 'anonymous'),
-      link(href: '/vite-production/assets/vue.ec0a97cc.css', crossorigin: 'anonymous'),
+      link(href: '/vite-production/assets/app.517bf154.css'),
+      link(href: '/vite-production/assets/theme.e6d9734b.css'),
+      link(href: '/vite-production/assets/vue.ec0a97cc.css'),
     ].join, vite_typescript_tag('main')
 
     assert_equal vite_javascript_tag('main.ts'),

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -34,7 +34,7 @@ module ViteRails::TagHelpers
     entries = vite_manifest.resolve_entries(*names, type: asset_type)
     tags = javascript_include_tag(*entries.fetch(:scripts), crossorigin: crossorigin, type: type, extname: false, **options)
     tags << vite_preload_tag(*entries.fetch(:imports), crossorigin: crossorigin, **options) unless skip_preload_tags
-    tags << stylesheet_link_tag(*entries.fetch(:stylesheets), media: media, crossorigin: crossorigin, **options) unless skip_style_tags
+    tags << stylesheet_link_tag(*entries.fetch(:stylesheets), media: media, **options) unless skip_style_tags
     tags
   end
 


### PR DESCRIPTION
### Description 📖

Fixes [189](https://github.com/ElMassimo/vite_ruby/issues/189)

