### PR TITLE
fix: disable emptyOutDir in non-development modes

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -116,7 +116,7 @@ export default defineConfig({
 ## Emptying the Output Dir 📦
 
 Another difference with Vite's defaults, is that <kbd>[emptyOutDir]</kbd>
-is disabled in production mode to provide better support for deployments that
+is disabled in non-development mode to provide better support for deployments that
 don't use a CDN.
 
 Keeping assets from previous builds helps to prevent downtime when deploying in the same host.

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -37,11 +37,11 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const fs = { allow: [projectRoot], strict: true }
   const server = { host, https, port, strictPort: true, fs }
 
-  const isDevelopment = config.mode === 'development'
+  const isLocal = config.mode === 'development' || config.mode === 'test'
 
   const build = {
-    emptyOutDir: userConfig.build?.emptyOutDir ?? isDevelopment,
-    sourcemap: !isDevelopment,
+    emptyOutDir: userConfig.build?.emptyOutDir ?? isLocal,
+    sourcemap: !isLocal,
     ...userConfig.build,
     assetsDir,
     manifest: true,

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -37,11 +37,11 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const fs = { allow: [projectRoot], strict: true }
   const server = { host, https, port, strictPort: true, fs }
 
-  const isProduction = config.mode === 'production'
+  const isDevelopment = config.mode === 'development'
 
   const build = {
-    emptyOutDir: userConfig.build?.emptyOutDir ?? !isProduction,
-    sourcemap: isProduction,
+    emptyOutDir: userConfig.build?.emptyOutDir ?? isDevelopment,
+    sourcemap: !isDevelopment,
     ...userConfig.build,
     assetsDir,
     manifest: true,

--- a/vite-plugin-ruby/tests/index.spec.ts
+++ b/vite-plugin-ruby/tests/index.spec.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest'
+import { defaultConfig } from '@plugin/config'
+import ViteRuby from '@plugin/index'
+
+describe('index', () => {
+  test('config', () => {
+    const plugin = ViteRuby()
+    const pluginConfig = plugin[0].config
+    defaultConfig.configPath = './default.vite.json'
+
+    const productionConfig = pluginConfig(defaultConfig, { mode: 'production' })
+    expect(productionConfig.build.emptyOutDir).toBe(false)
+    expect(productionConfig.build.sourcemap).toBe(true)
+
+    const stagingConfig = pluginConfig(defaultConfig, { mode: 'staging' })
+    expect(stagingConfig.build.emptyOutDir).toBe(false)
+    expect(stagingConfig.build.sourcemap).toBe(true)
+
+    const developmentConfig = pluginConfig(defaultConfig, { mode: 'development' })
+    expect(developmentConfig.build.emptyOutDir).toBe(true)
+    expect(developmentConfig.build.sourcemap).toBe(false)
+  })
+})


### PR DESCRIPTION
### Description 📖

This pull request solves the issue discussed in https://github.com/ElMassimo/vite_ruby/discussions/186
Staging mode was inconsistent with production mode

### Background 📜

This was happening because the code was checking for `mode === 'production'`, but we need the same settings in all non-dev environments (not sure about CI but I guess?).

### The Fix 🔨

Replaced previous `isProduction` with `!isDevelopment`, also added a test but my test game is pretty bad, feel free to rework it
