### PR TITLE
fix: prevent error when using a proc in asset_host (close #202)

### DIFF
--- a/vite_rails/lib/vite_rails/config.rb
+++ b/vite_rails/lib/vite_rails/config.rb
@@ -4,8 +4,9 @@ module ViteRails::Config
   # Override: Default values for a Rails application.
   def config_defaults
     require 'rails'
+    asset_host = Rails.application&.config&.action_controller&.asset_host
     super(
-      asset_host: Rails.application&.config&.action_controller&.asset_host,
+      asset_host: asset_host.is_a?(Proc) ? nil : asset_host,
       mode: Rails.env.to_s,
       root: Rails.root || Dir.pwd,
     )

--- a/vite_rails_legacy/lib/vite_rails_legacy/config.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/config.rb
@@ -4,8 +4,9 @@ module ViteRailsLegacy::Config
   # Override: Default values for a Rails application.
   def config_defaults
     require 'rails'
+    asset_host = Rails.application&.config&.action_controller&.asset_host
     super(
-      asset_host: Rails.application&.config&.action_controller&.asset_host,
+      asset_host: asset_host.is_a?(Proc) ? nil : asset_host,
       mode: Rails.env.to_s,
       root: Rails.root || Dir.pwd,
     )

--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -121,7 +121,7 @@ private
         'config_path' => option_from_env('config_path') || DEFAULT_CONFIG.fetch('config_path'),
         'mode' => option_from_env('mode') || mode,
         'root' => option_from_env('root') || root,
-      }
+      }.select { |_, value| value }
     end
 
     # Internal: Used to load a JSON file from the specified path.


### PR DESCRIPTION
### Description 📖

This pull request fixes #202 by ignoring `asset_host` in Rails when configured with a `Proc`.

### Background 📜

Usually, [the asset host will be used as the base](https://github.com/ElMassimo/vite_ruby/blob/main/vite-plugin-ruby/src/config.ts#L108) for Vite, which is a good default, especially when `asset_host` is configured to target a CDN.

Rails allows to use a `Proc` to dynamically configure `asset_host`, allowing to return different values depending on the `source`, the URL of an asset.

Since there's no "right" value to pass to Vite when `asset_host` is a `Proc`, it's better to ignore it, which in most cases would still allow assets to be correctly resolved.

In the few cases where this is not desired, [`assetHost` can be explicitly configured](https://vite-ruby.netlify.app/config/index.html#assethost) in `config/vite.json`, `config/vite.rb`, or via environment variables.
