### PR TITLE
feat: add vite_asset_url helper

### DIFF
--- a/docs/src/guide/rails.md
+++ b/docs/src/guide/rails.md
@@ -71,7 +71,7 @@ For images you can use <kbd>vite_image_tag</kbd>:
 For other types of assets, you can use <kbd>[vite_asset_path][helpers]</kbd> and pass the resulting URI to the appropriate tag helper.
 
 ```erb
-<link rel="apple-touch-icon" type="image/png" href="<%= vite_asset_path 'images/favicon.png' %>" />
+<link rel="apple-touch-icon" type="image/png" href="<%= vite_asset_url 'images/favicon.png' %>" />
 <link rel="prefetch" href="<%= vite_asset_path 'typography.css' %>" />
 ```
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -78,6 +78,13 @@ class HelperTest < HelperTestCase
     }
   end
 
+  def test_vite_asset_url
+    assert_equal 'https://example.com/vite-production/assets/main.9dcad042.js', vite_asset_url('main.ts')
+    with_dev_server_running {
+      assert_equal 'https://example.com/vite-dev/entrypoints/main.ts', vite_asset_url('main.ts')
+    }
+  end
+
   def test_vite_stylesheet_tag
     assert_similar link(href: '/vite-production/assets/app.517bf154.css'), vite_stylesheet_tag('app')
     assert_equal vite_stylesheet_tag('app'), vite_stylesheet_tag('app.css')

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -21,14 +21,14 @@ module ViteRails::TagHelpers
   def vite_asset_path(name, **options)
     path_to_asset vite_manifest.path_for(name, **options)
   end
-  
+
   # Public: Resolves the url for the specified Vite asset.
   #
   # Example:
   #   <%= vite_asset_url 'calendar.css' %> # => "https://example.com/vite/assets/calendar-1016838bab065ae1e122.css"
   def vite_asset_url(name, **options)
     url_to_asset vite_manifest.path_for(name, **options)
-  end  
+  end
 
   # Public: Renders a <script> tag for the specified Vite entrypoints.
   def vite_javascript_tag(*names,

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -21,6 +21,14 @@ module ViteRails::TagHelpers
   def vite_asset_path(name, **options)
     path_to_asset vite_manifest.path_for(name, **options)
   end
+  
+  # Public: Resolves the url for the specified Vite asset.
+  #
+  # Example:
+  #   <%= vite_asset_url 'calendar.css' %> # => "https://example.com/vite/assets/calendar-1016838bab065ae1e122.css"
+  def vite_asset_url(name, **options)
+    url_to_asset vite_manifest.path_for(name, **options)
+  end  
 
   # Public: Renders a <script> tag for the specified Vite entrypoints.
   def vite_javascript_tag(*names,

--- a/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
@@ -22,6 +22,14 @@ module ViteRailsLegacy::TagHelpers
     path_to_asset vite_manifest.path_for(name, **options)
   end
 
+  # Public: Resolves the url for the specified Vite asset.
+  #
+  # Example:
+  #   <%= vite_asset_url 'calendar.css' %> # => "https://example.com/vite/assets/calendar-1016838bab065ae1e122.css"
+  def vite_asset_url(name, **options)
+    url_to_asset vite_manifest.path_for(name, **options)
+  end
+
   # Public: Renders a <script> tag for the specified Vite entrypoints.
   def vite_javascript_tag(*names,
                           type: 'module',


### PR DESCRIPTION
### Description 📖

Add vite_asset_url helper

### Background 📜

Needed url to the asset instead of path

### The Fix 🔨

By adding the appropriate tag helper

### Screenshots 📷
