### PR TITLE
feat: add support for SSR builds (experimental)

### DIFF
--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -32,7 +32,7 @@ const debug = createDebugger('vite-plugin-ruby:config')
 // config file, and configures the entrypoints and manifest generation.
 function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const config = loadConfiguration(env.mode, projectRoot, userConfig)
-  const { assetsDir, base, outDir, host, https, port, root, entrypoints } = config
+  const { assetsDir, base, outDir, host, https, port, root, entrypoints, isSSR } = config
 
   const fs = { allow: [projectRoot], strict: true }
   const server = { host, https, port, strictPort: true, fs }
@@ -48,7 +48,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
     outDir,
     rollupOptions: {
       input: Object.fromEntries(filterEntrypointsForRollup(entrypoints)),
-      output: {
+      output: isSSR ? {} : {
         ...outputOptions(assetsDir),
         ...userConfig.build?.rollupOptions?.output,
       },

--- a/vite-plugin-ruby/src/types.ts
+++ b/vite-plugin-ruby/src/types.ts
@@ -25,6 +25,7 @@ export interface PluginOptions {
   root: string
   outDir: string
   base: string
+  isSSR: boolean | string
 }
 
 export type Entrypoints = Array<[string, string]>

--- a/vite-plugin-ruby/tests/entrypoints.spec.ts
+++ b/vite-plugin-ruby/tests/entrypoints.spec.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'path'
+import { describe, test, expect } from 'vitest'
+import { defaultConfig, resolveEntrypointFiles } from '@plugin/config'
+import type { ResolvedConfig } from '@plugin/types'
+
+const entrypointsFor = ({ isSSR = false, ...config }: Partial<ResolvedConfig> & { isSSR?: boolean }) => {
+  config = { ...defaultConfig, ...config }
+  return resolveEntrypointFiles(resolve('example'), config.sourceCodeDir, config, isSSR)
+}
+
+const expectEntrypoints = (config: Partial<ResolvedConfig> & { isSSR?: boolean }) =>
+  expect(entrypointsFor(config))
+
+describe('resolveEntrypointFiles', () => {
+  test('client build', () => {
+    expectEntrypoints({}).toEqual([
+      ['app/frontend/entrypoints/app.css', resolve('example/app/frontend/entrypoints/app.css')],
+      ['app/frontend/entrypoints/main.ts', resolve('example/app/frontend/entrypoints/main.ts')],
+      ['app/frontend/entrypoints/sassy.scss', resolve('example/app/frontend/entrypoints/sassy.scss')],
+      ['app/frontend/entrypoints/frameworks/vue.js', resolve('example/app/frontend/entrypoints/frameworks/vue.js')],
+      ['app/frontend/images/logo.png', resolve('example/app/frontend/images/logo.png')],
+      ['app/frontend/images/logo.svg', resolve('example/app/frontend/images/logo.svg')],
+    ])
+  })
+
+  test('ssr build', () => {
+    expectEntrypoints({ isSSR: true }).toEqual([
+      ['ssr', resolve('example/app/frontend/ssr/ssr.ts')],
+    ])
+
+    expect(() => entrypointsFor({ sourceCodeDir: 'app/missing', isSSR: true }))
+      .toThrow('No SSR entrypoint available')
+
+    expect(() => entrypointsFor({ sourceCodeDir: 'app/incorrect', isSSR: true }))
+      .toThrow('Expected a single SSR entrypoint, found')
+  })
+})

--- a/vite-plugin-ruby/tests/index.spec.ts
+++ b/vite-plugin-ruby/tests/index.spec.ts
@@ -23,5 +23,9 @@ describe('config', () => {
     const testConfig = pluginConfig(defaultConfig, { mode: 'test' })
     expect(testConfig.build.emptyOutDir).toBe(true)
     expect(testConfig.build.sourcemap).toBe(false)
+
+    expect(() => {
+      pluginConfig({ ...defaultConfig, build: { ssr: true } }, { mode: 'production' })
+    }).toThrow('No SSR entrypoint available')
   })
 })


### PR DESCRIPTION
### Description 📖

This pull request adds support for SSR builds, using an approach based on [this prototype](https://github.com/ElMassimo/inertia-rails-ssr-template/commit/b38ef8eb108cd98dea2aadf7d2fbdac72746297b).

The goal is to support use cases such as [SSR with Inertia](https://github.com/inertiajs/inertia-rails/pull/74), and pave the way for other use cases that can benefit from an SSR build (such as Rails API + Node.js SSR).

### Background 📜 

By detecting whether the `ssr` flag was set when triggering the build, `vite-plugin-ruby` will set an SSR entrypoint instead, and skip any output options related to fingerprinting the resulting assets.

This is experimental, these initial conventions are subject to change in patch releases:

- The SSR entrypoint should be a `{sourceCodeDir}/ssr/ssr.js` file. TypeScript and JSX are supported.
- The output dir will have an `-ssr` prefix to be separate from client-side builds, for example: `public/vite-ssr`.

### SSR 🚀

The SSR entrypoint can import any universal code (supporting both node.js and browsers), and leverage the `~/` alias as needed.

You can leverage `import.meta.env.SSR` to execute different code depending on the environment, for example:

```ts
if (import.meta.env.SSR)
  require('fs').readFileSync(...) // SSR build runs in node.js
else
  await window.showOpenFilePicker() // Client build runs in the browser
```

#### Building in SSR mode

To create an SSR build:

```
bin/vite build --force -- --ssr
```

To run the SSR build:

```
node public/vite-ssr/ssr.js
```

### Upcoming 🔮 

This experimental version does not address build caching, which requires further changes in `vite_ruby` to ensure the SSR build is not skipped (for now, using the `--force` flag should do the trick).