### PR TITLE
feat: add support for SSR builds (experimental)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
-    loofah (2.15.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     m (1.5.1)
@@ -117,7 +117,7 @@ GEM
       ruby-progressbar
     minitest-stub_any_instance (1.0.2)
     nio4r (2.5.7)
-    nokogiri (1.13.3)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.21.0)

--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -2,10 +2,10 @@
 [config reference]: https://vitejs.dev/config/
 [plugins]: https://vitejs.dev/plugins/
 [entrypoints]: /guide/development.html#entrypoints-⤵%EF%B8%8F
-[json config]: /config/#shared-configuration-file-%F0%9F%93%84
+[json config]: /config/#shared-configuration-file-%f0%9f%93%84
 [sourceCodeDir]: /config/#sourcecodedir
 [autoBuild]: /config/#autobuild
-[entrypointsDir]: /config/#entrypointsDir
+[entrypointsDir]: /config/#entrypointsdir
 [publicOutputDir]: /config/#publicoutputdir
 [additionalEntrypoints]: /config/#additionalentrypoints
 [watchAdditionalPaths]: /config/#watchadditionalpaths
@@ -21,6 +21,7 @@
 [Vite config file]: /config/#configuring-vite-⚡
 [runtime env var]: https://github.com/ElMassimo/vite_ruby/discussions/159#discussioncomment-1841817
 [emptyOutDir]: https://vitejs.dev/config/#build-emptyoutdir
+[inertia-ssr]: https://github.com/ElMassimo/inertia-rails-ssr-template
 
 # Configuring Vite Ruby
 
@@ -343,6 +344,32 @@ You can customize this behavior using the following options.
     },
   })
   ```
+## SSR Options
+
+The purpose of SSR builds within _Vite Ruby_ is to support the creation of
+servers based on Node.js, which can be used in combination with Rails, such as
+when using [Inertia.js in SSR mode][inertia-ssr].
+
+### ssrBuildEnabled
+
+- **Default:** `false`
+- **Env Var:** `VITE_RUBY_SSR_BUILD_ENABLED`
+
+  Whether to build an SSR entrypoint when precompiling assets.
+
+### ssrEntrypoint
+
+- **Default:** `~/ssr/ssr.{js,ts,jsx,tsx}`
+- **Env Var:** `VITE_RUBY_SSR_ENTRYPOINT`
+
+  A file glob specifying a pattern that matches the SSR entrypoint to build.
+
+### ssrOutputDir
+
+- **Default:** `public/ssr`
+- **Env Var:** `VITE_RUBY_SSR_OUTPUT_DIR`
+
+   * Specify the output directory for the SSR build (relative to <kbd>[root]</kbd>).
 
 <br>
 <br>

--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -21,6 +21,9 @@
 [Vite config file]: /config/#configuring-vite-⚡
 [runtime env var]: https://github.com/ElMassimo/vite_ruby/discussions/159#discussioncomment-1841817
 [emptyOutDir]: https://vitejs.dev/config/#build-emptyoutdir
+[ssrEntrypoint]: /config/#ssrentrypoint
+[ssrOutputDir]: /config/#ssroutputdir
+[ssr mode]: https://vitejs.dev/guide/ssr.html#server-side-rendering
 [inertia-ssr]: https://github.com/ElMassimo/inertia-rails-ssr-template
 
 # Configuring Vite Ruby
@@ -346,30 +349,50 @@ You can customize this behavior using the following options.
   ```
 ## SSR Options
 
-The purpose of SSR builds within _Vite Ruby_ is to support the creation of
-servers based on Node.js, which can be used in combination with Rails, such as
-when using [Inertia.js in SSR mode][inertia-ssr].
+_Vite Ruby_ supports building your app in [SSR mode], obtaining a Node.js app
+that can be used in combination with Rails, such as when using [Inertia.js in SSR mode][inertia-ssr].
+
+When building in SSR mode, _Vite Ruby_ will use <kbd>[ssrEntrypoint]</kbd> as
+the single entrypoint, and output the resulting app in a <kbd>[ssrOutputDir]/ssr.js</kbd> script.
+
+:::tip Running the server
+The resulting Node.js script can be conveniently executed with <kbd>bin/vite ssr</kbd>.
+:::
+
+::: warning Experimental
+
+Until the API is stabilized, these options __do not follow semantic versioning__.
+
+Lock `vite_ruby` and `vite-plugin-ruby` down to patch releases to prevent breaking changes.
+:::
 
 ### ssrBuildEnabled
 
 - **Default:** `false`
 - **Env Var:** `VITE_RUBY_SSR_BUILD_ENABLED`
 
-  Whether to build an SSR entrypoint when precompiling assets.
+  When enabled, running <kbd>rake assets:precompile</kbd> will also run an SSR
+  build, simplifying the deployment setup.
+
+:::tip Manual SSR Builds
+You can build the app in SSR mode using <kbd>bin/vite build --ssr</kbd>.
+:::
 
 ### ssrEntrypoint
 
 - **Default:** `~/ssr/ssr.{js,ts,jsx,tsx}`
 - **Env Var:** `VITE_RUBY_SSR_ENTRYPOINT`
 
-  A file glob specifying a pattern that matches the SSR entrypoint to build.
+  A file glob pattern that matches the entrypoint file for SSR builds, for example: `app/frontend/ssr/ssr.ts`.
+
+  `~/` can be used in the glob pattern as an alias for the <kbd>[sourceCodeDir]</kbd>.
 
 ### ssrOutputDir
 
 - **Default:** `public/ssr`
 - **Env Var:** `VITE_RUBY_SSR_OUTPUT_DIR`
 
-   * Specify the output directory for the SSR build (relative to <kbd>[root]</kbd>).
+  Specify the output directory for the SSR build (relative to <kbd>[root]</kbd>).
 
 <br>
 <br>

--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -347,7 +347,7 @@ You can customize this behavior using the following options.
     },
   })
   ```
-## SSR Options
+## SSR Options (experimental)
 
 _Vite Ruby_ supports building your app in [SSR mode], obtaining a Node.js app
 that can be used in combination with Rails, such as when using [Inertia.js in SSR mode][inertia-ssr].

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -12,7 +12,7 @@ class BuilderTest < ViteRuby::Test
 
   def setup
     super
-    builder.send(:last_build_path).tap do |path|
+    [builder.send(:last_build_path, ssr: true), builder.send(:last_build_path, ssr: false)].each do |path|
       path.delete if path.exist?
     end
   end
@@ -59,7 +59,8 @@ class BuilderTest < ViteRuby::Test
   end
 
   def test_last_build_path
-    assert_equal builder.send(:last_build_path).basename.to_s, "last-build-#{ ViteRuby.config.mode }.json"
+    assert_equal builder.send(:last_build_path, ssr: false).basename.to_s, "last-build-#{ ViteRuby.config.mode }.json"
+    assert_equal builder.send(:last_build_path, ssr: true).basename.to_s, "last-ssr-build-#{ ViteRuby.config.mode }.json"
   end
 
   def test_watched_files_digest

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -97,6 +97,12 @@ class BuilderTest < ViteRuby::Test
     stub_runner(success: true) { assert builder.build }
   end
 
+  def test_build_cache
+    build = ViteRuby::Build.from_previous(Pathname.new(__FILE__), 'digest')
+    assert_equal build.timestamp, 'never'
+    assert_equal build.retry_failed?, true
+  end
+
 private
 
   def stub_runner(success:, &block)

--- a/test/mounted_app/test/dummy/config/vite.json
+++ b/test/mounted_app/test/dummy/config/vite.json
@@ -1,6 +1,7 @@
 {
   "all": {
     "sourceCodeDir": "app/frontend",
+    "ssrBuildEnabled": true,
     "watchAdditionalPaths": []
   },
   "development": {

--- a/test/rake_tasks_test.rb
+++ b/test/rake_tasks_test.rb
@@ -7,6 +7,7 @@ class RakeTasksTest < ViteRuby::Test
     assert ViteRuby.install_tasks
     output = Dir.chdir(test_app_path) { `rake -T` }
     assert_includes output, 'vite:build'
+    assert_includes output, 'vite:build_ssr'
     assert_includes output, 'vite:clean'
     assert_includes output, 'vite:clobber'
     assert_includes output, 'vite:install_dependencies'

--- a/test/test_app/app/frontend/ssr/ssr.ts
+++ b/test/test_app/app/frontend/ssr/ssr.ts
@@ -1,0 +1,8 @@
+import http from 'http'
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200)
+  res.end('Hello, World!!!')
+})
+
+server.listen(8080)

--- a/test/test_app/config/vite.json
+++ b/test/test_app/config/vite.json
@@ -10,11 +10,9 @@
     "publicOutputDir": "vite-test"
   },
   "production": {
-    "ssrBuildEnabled": true,
     "publicOutputDir": "vite-production"
   },
   "staging": {
-    "ssrBuildEnabled": true,
     "publicOutputDir": "vite-staging"
   }
 }

--- a/test/test_app/config/vite.json
+++ b/test/test_app/config/vite.json
@@ -10,9 +10,11 @@
     "publicOutputDir": "vite-test"
   },
   "production": {
+    "ssrBuildEnabled": true,
     "publicOutputDir": "vite-production"
   },
   "staging": {
+    "ssrBuildEnabled": true,
     "publicOutputDir": "vite-staging"
   }
 }

--- a/vite-plugin-ruby/default.vite.json
+++ b/vite-plugin-ruby/default.vite.json
@@ -17,5 +17,8 @@
   "hideBuildConsoleOutput": false,
   "viteBinPath": "node_modules/.bin/vite",
   "watchAdditionalPaths": [],
-  "base": ""
+  "base": "",
+  "ssrBuildEnabled": false,
+  "ssrEntrypoint": "~/ssr/ssr.{js,ts,jsx,tsx}",
+  "ssrOutputDir": "public/ssr"
 }

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -40,7 +40,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const isLocal = config.mode === 'development' || config.mode === 'test'
 
   const build = {
-    emptyOutDir: userConfig.build?.emptyOutDir ?? isLocal,
+    emptyOutDir: userConfig.build?.emptyOutDir ?? (ssrBuild || isLocal),
     sourcemap: !isLocal,
     ...userConfig.build,
     assetsDir,

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -44,7 +44,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
     sourcemap: !isLocal,
     ...userConfig.build,
     assetsDir,
-    manifest: true,
+    manifest: !ssrBuild,
     outDir,
     rollupOptions: {
       input: Object.fromEntries(filterEntrypointsForRollup(entrypoints)),

--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -32,7 +32,7 @@ const debug = createDebugger('vite-plugin-ruby:config')
 // config file, and configures the entrypoints and manifest generation.
 function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
   const config = loadConfiguration(env.mode, projectRoot, userConfig)
-  const { assetsDir, base, outDir, host, https, port, root, entrypoints, isSSR } = config
+  const { assetsDir, base, outDir, host, https, port, root, entrypoints, ssrBuild } = config
 
   const fs = { allow: [projectRoot], strict: true }
   const server = { host, https, port, strictPort: true, fs }
@@ -48,7 +48,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
     outDir,
     rollupOptions: {
       input: Object.fromEntries(filterEntrypointsForRollup(entrypoints)),
-      output: isSSR ? {} : {
+      output: ssrBuild ? {} : {
         ...outputOptions(assetsDir),
         ...userConfig.build?.rollupOptions?.output,
       },

--- a/vite-plugin-ruby/src/manifest.ts
+++ b/vite-plugin-ruby/src/manifest.ts
@@ -6,7 +6,7 @@ import createDebugger from 'debug'
 import type { Plugin, ResolvedConfig } from 'vite'
 
 import { OutputBundle, PluginContext } from 'rollup'
-import { UnifiedConfig } from '../dist'
+import { UnifiedConfig } from './types'
 import { filterEntrypointAssets, filterStylesheetAssets } from './config'
 import { withoutExtension } from './utils'
 
@@ -79,6 +79,8 @@ export function assetsManifestPlugin (): Plugin {
       viteRubyConfig = (config as any).viteRuby
     },
     async generateBundle (_options, bundle) {
+      if (!config.build.manifest) return
+
       const manifest: AssetsManifest = new Map()
       extractChunkStylesheets(bundle, manifest)
 

--- a/vite-plugin-ruby/src/types.ts
+++ b/vite-plugin-ruby/src/types.ts
@@ -17,6 +17,19 @@ export interface ResolvedConfig {
   publicOutputDir: string
   watchAdditionalPaths: string[]
   base: string
+  /**
+   * @private
+   * In the context of the internal code, whether an SSR build should be performed.
+   */
+  ssrBuild: boolean
+  /**
+   * A file glob specifying a pattern that matches the SSR entrypoint to build.
+   */
+  ssrEntrypoint: string
+  /**
+   * Specify the output directory for the SSR build (relative to the project root).
+   */
+  ssrOutputDir: string
 }
 
 export type Config = Partial<ResolvedConfig>
@@ -25,7 +38,6 @@ export interface PluginOptions {
   root: string
   outDir: string
   base: string
-  isSSR: boolean | string
 }
 
 export type Entrypoints = Array<[string, string]>

--- a/vite-plugin-ruby/tests/entrypoints.spec.ts
+++ b/vite-plugin-ruby/tests/entrypoints.spec.ts
@@ -3,12 +3,12 @@ import { describe, test, expect } from 'vitest'
 import { defaultConfig, resolveEntrypointFiles } from '@plugin/config'
 import type { ResolvedConfig } from '@plugin/types'
 
-const entrypointsFor = ({ isSSR = false, ...config }: Partial<ResolvedConfig> & { isSSR?: boolean }) => {
+const entrypointsFor = (config: Partial<ResolvedConfig>) => {
   config = { ...defaultConfig, ...config }
-  return resolveEntrypointFiles(resolve('example'), config.sourceCodeDir, config, isSSR)
+  return resolveEntrypointFiles(resolve('example'), config.sourceCodeDir, config)
 }
 
-const expectEntrypoints = (config: Partial<ResolvedConfig> & { isSSR?: boolean }) =>
+const expectEntrypoints = (config: Partial<ResolvedConfig>) =>
   expect(entrypointsFor(config))
 
 describe('resolveEntrypointFiles', () => {
@@ -24,14 +24,14 @@ describe('resolveEntrypointFiles', () => {
   })
 
   test('ssr build', () => {
-    expectEntrypoints({ isSSR: true }).toEqual([
+    expectEntrypoints({ ssrBuild: true }).toEqual([
       ['ssr', resolve('example/app/frontend/ssr/ssr.ts')],
     ])
 
-    expect(() => entrypointsFor({ sourceCodeDir: 'app/missing', isSSR: true }))
+    expect(() => entrypointsFor({ sourceCodeDir: 'app/missing', ssrBuild: true }))
       .toThrow('No SSR entrypoint available')
 
-    expect(() => entrypointsFor({ sourceCodeDir: 'app/incorrect', isSSR: true }))
+    expect(() => entrypointsFor({ sourceCodeDir: 'app/incorrect', ssrBuild: true }))
       .toThrow('Expected a single SSR entrypoint, found')
   })
 })

--- a/vite_ruby/default.vite.json
+++ b/vite_ruby/default.vite.json
@@ -17,5 +17,8 @@
   "hideBuildConsoleOutput": false,
   "viteBinPath": "node_modules/.bin/vite",
   "watchAdditionalPaths": [],
-  "base": ""
+  "base": "",
+  "ssrBuildEnabled": false,
+  "ssrEntrypoint": "~/ssr/ssr.{js,ts,jsx,tsx}",
+  "ssrOutputDir": "public/ssr"
 }

--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -14,6 +14,17 @@ namespace :vite do
     ViteRuby.commands.build_from_task
   end
 
+  desc 'Bundle a Node.js app from the SSR entrypoint using ViteRuby'
+  task build_ssr: :'vite:verify_install' do
+    ViteRuby.commands.build_from_task('--ssr')
+  end
+
+  desc 'Bundle entrypoints using Vite Ruby (SSR only if enabled)'
+  task build_all: :'vite:verify_install' do
+    ViteRuby.commands.build_from_task
+    ViteRuby.commands.build_from_task('--ssr') if ViteRuby.config.ssr_build_enabled
+  end
+
   desc 'Remove old bundles created by ViteRuby'
   task :clean, [:keep, :age] => :'vite:verify_install' do |_, args|
     ViteRuby.commands.clean_from_task(args)
@@ -45,10 +56,10 @@ unless ENV['VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION'] == 'true'
     Rake::Task['assets:precompile'].enhance do |task|
       prefix = task.name.split(/#|assets:precompile/).first
       Rake::Task["#{ prefix }vite:install_dependencies"].invoke
-      Rake::Task["#{ prefix }vite:build"].invoke
+      Rake::Task["#{ prefix }vite:build_all"].invoke
     end
   else
-    Rake::Task.define_task('assets:precompile' => ['vite:install_dependencies', 'vite:build'])
+    Rake::Task.define_task('assets:precompile' => ['vite:install_dependencies', 'vite:build_all'])
   end
 
   unless Rake::Task.task_defined?('assets:clean')

--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -9,27 +9,27 @@ namespace :vite do
     ViteRuby.commands.install_binstubs
   end
 
-  desc 'Compile JavaScript packs using vite for production with digests'
+  desc 'Bundle frontend entrypoints using ViteRuby'
   task build: :'vite:verify_install' do
     ViteRuby.commands.build_from_task
   end
 
-  desc 'Remove old compiled vites'
+  desc 'Remove old bundles created by ViteRuby'
   task :clean, [:keep, :age] => :'vite:verify_install' do |_, args|
     ViteRuby.commands.clean_from_task(args)
   end
 
-  desc 'Remove the vite build output directory'
+  desc 'Remove the build output directory for ViteRuby'
   task clobber: :'vite:verify_install' do
     ViteRuby.commands.clobber
   end
 
-  desc 'Verifies if ViteRuby is properly installed in this application'
+  desc 'Verify if ViteRuby is properly installed in the app'
   task :verify_install do
     ViteRuby.commands.verify_install
   end
 
-  desc 'Ensures build dependencies like Vite are installed when compiling assets'
+  desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
     system({ 'NODE_ENV' => 'development' }, 'npx ci --yes')
   end

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -11,6 +11,7 @@ loader.ignore("#{ __dir__ }/install")
 loader.ignore("#{ __dir__ }/tasks")
 loader.ignore("#{ __dir__ }/exe")
 loader.inflector.inflect('cli' => 'CLI')
+loader.inflector.inflect('ssr' => 'SSR')
 loader.inflector.inflect('io' => 'IO')
 loader.setup
 

--- a/vite_ruby/lib/vite_ruby/build.rb
+++ b/vite_ruby/lib/vite_ruby/build.rb
@@ -1,17 +1,26 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'time'
 
 # Internal: Value object with information about the last build.
-ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current_digest) do
+ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current_digest, :last_build_path) do
   # Internal: Combines information from a previous build with the current digest.
-  def self.from_previous(attrs, current_digest)
+  def self.from_previous(last_build_path, current_digest)
+    attrs = begin
+      # Reads metadata recorded on the last build, if it exists.
+      last_build_path.exist? ? JSON.parse(last_build_path.read.to_s) : {}
+    rescue JSON::JSONError, Errno::ENOENT, Errno::ENOTDIR
+      {}
+    end
+
     new(
       attrs['success'],
       attrs['timestamp'] || 'never',
       attrs['vite_ruby'] || 'unknown',
       attrs['digest'] || 'none',
       current_digest,
+      last_build_path,
     )
   end
 
@@ -42,11 +51,23 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current
       Time.now.strftime('%F %T'),
       ViteRuby::VERSION,
       current_digest,
+      current_digest,
+      last_build_path,
     )
+  end
+
+  # Internal: Writes the result of the new build to a local file.
+  def write_to_cache
+    last_build_path.write to_json
   end
 
   # Internal: Returns a JSON string with the metadata of the build.
   def to_json(*_args)
-    JSON.pretty_generate(to_h)
+    JSON.pretty_generate(
+      success: success,
+      timestamp: timestamp,
+      vite_ruby: vite_ruby,
+      digest: digest,
+    )
   end
 end

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -50,7 +50,7 @@ private
 
   # Internal: The file path where metadata of the last build is stored.
   def last_build_path
-    config.build_cache_dir.join("last-build-#{ config.mode }.json")
+    config.build_cache_dir.join("last-build-#{ config.mode }#{ config.ssr? && '-ssr' }.json")
   end
 
   # Internal: Returns a digest of all the watched files, allowing to detect

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
 require 'digest/sha1'
 
 # Public: Keeps track of watched files and triggers builds as needed.
@@ -12,7 +11,8 @@ class ViteRuby::Builder
   # Public: Checks if the watched files have changed since the last compilation,
   # and triggers a Vite build if any files have changed.
   def build(*args)
-    last_build = last_build_metadata
+    last_build = last_build_metadata(ssr: args.include?('--ssr'))
+
     if args.delete('--force') || last_build.stale?
       build_with_vite(*args).tap { |success| record_build_metadata(success, last_build) }
     elsif last_build.success
@@ -25,8 +25,8 @@ class ViteRuby::Builder
   end
 
   # Internal: Reads the result of the last compilation from disk.
-  def last_build_metadata
-    ViteRuby::Build.from_previous(last_build_attrs, watched_files_digest)
+  def last_build_metadata(ssr: false)
+    ViteRuby::Build.from_previous(last_build_path(ssr: ssr), watched_files_digest)
   end
 
 private
@@ -35,22 +35,15 @@ private
 
   def_delegators :@vite_ruby, :config, :logger, :run
 
-  # Internal: Reads metadata recorded on the last build, if it exists.
-  def last_build_attrs
-    last_build_path.exist? ? JSON.parse(last_build_path.read.to_s) : {}
-  rescue JSON::JSONError, Errno::ENOENT, Errno::ENOTDIR
-    {}
-  end
-
   # Internal: Writes a digest of the watched files to disk for future checks.
   def record_build_metadata(success, build)
     config.build_cache_dir.mkpath
-    last_build_path.write build.with_result(success).to_json
+    build.with_result(success).write_to_cache
   end
 
   # Internal: The file path where metadata of the last build is stored.
-  def last_build_path
-    config.build_cache_dir.join("last-build-#{ config.mode }#{ config.ssr? && '-ssr' }.json")
+  def last_build_path(ssr:)
+    config.build_cache_dir.join("last#{ '-ssr' if ssr }-build-#{ config.mode }.json")
   end
 
   # Internal: Returns a digest of all the watched files, allowing to detect

--- a/vite_ruby/lib/vite_ruby/cli.rb
+++ b/vite_ruby/lib/vite_ruby/cli.rb
@@ -11,6 +11,7 @@ class ViteRuby::CLI
   register 'clobber', Clobber, aliases: %w[clean clear]
   register 'dev', Dev, aliases: %w[d serve]
   register 'install', Install
+  register 'ssr', SSR
   register 'version', Version, aliases: ['v', '-v', '--version', 'info']
   register 'upgrade', Upgrade, aliases: ['update']
   register 'upgrade_packages', UpgradePackages, aliases: ['update_packages']

--- a/vite_ruby/lib/vite_ruby/cli/build.rb
+++ b/vite_ruby/lib/vite_ruby/cli/build.rb
@@ -5,6 +5,7 @@ class ViteRuby::CLI::Build < ViteRuby::CLI::Vite
 
   desc 'Bundle all entrypoints using Vite.'
   shared_options
+  option(:ssr, desc: 'Build the SSR entrypoint instead', type: :boolean)
   option(:force, desc: 'Force the build even if assets have not changed', type: :boolean)
   option(:watch, desc: 'Start the Rollup watcher and rebuild on files changes', type: :boolean)
 

--- a/vite_ruby/lib/vite_ruby/cli/ssr.rb
+++ b/vite_ruby/lib/vite_ruby/cli/ssr.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ViteRuby::CLI::SSR < ViteRuby::CLI::Vite
+  DEFAULT_ENV = CURRENT_ENV || 'production'
+
+  desc 'Run the resulting app from building in SSR mode.'
+  executable_options
+
+  def call(mode:, inspect: false, trace_deprecation: false)
+    ViteRuby.env['VITE_RUBY_MODE'] = mode
+    cmd = [
+      'node',
+      ('--inspect-brk' if inspect),
+      ('--trace-deprecation' if trace_deprecation),
+      ViteRuby.config.ssr_output_dir.join('ssr.js'),
+    ]
+    Kernel.exec(*cmd.compact.map(&:to_s))
+  end
+end

--- a/vite_ruby/lib/vite_ruby/cli/vite.rb
+++ b/vite_ruby/lib/vite_ruby/cli/vite.rb
@@ -3,12 +3,16 @@
 class ViteRuby::CLI::Vite < Dry::CLI::Command
   CURRENT_ENV = ENV['RACK_ENV'] || ENV['RAILS_ENV']
 
-  def self.shared_options
+  def self.executable_options
     option(:mode, default: self::DEFAULT_ENV, values: %w[development production test], aliases: ['m'], desc: 'The build mode for Vite')
-    option(:clobber, desc: 'Clear cache and previous builds', type: :boolean, aliases: %w[clean clear])
-    option(:debug, desc: 'Run Vite in verbose mode, printing all debugging output', aliases: ['verbose'], type: :boolean)
     option(:inspect, desc: 'Run Vite in a debugging session with node --inspect-brk', aliases: ['inspect-brk'], type: :boolean)
     option(:trace_deprecation, desc: 'Run Vite in debugging mode with node --trace-deprecation', aliases: ['trace-deprecation'], type: :boolean)
+  end
+
+  def self.shared_options
+    executable_options
+    option(:debug, desc: 'Run Vite in verbose mode, printing all debugging output', aliases: ['verbose'], type: :boolean)
+    option(:clobber, desc: 'Clear cache and previous builds', type: :boolean, aliases: %w[clean clear])
   end
 
   def call(mode:, args: [], clobber: false, **boolean_opts)

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -23,7 +23,7 @@ class ViteRuby::Commands
 
   # Public: Removes all build cache and previously compiled assets.
   def clobber
-    dirs = [config.build_output_dir, config.build_cache_dir, config.vite_cache_dir]
+    dirs = [config.build_output_dir, config.ssr_output_dir, config.build_cache_dir, config.vite_cache_dir]
     dirs.each { |dir| dir.rmtree if dir.exist? }
     $stdout.puts "Removed vite cache and output dirs:\n\t#{ dirs.join("\n\t") }"
   end

--- a/vite_ruby/lib/vite_ruby/compatibility_check.rb
+++ b/vite_ruby/lib/vite_ruby/compatibility_check.rb
@@ -24,7 +24,7 @@ module ViteRuby::CompatibilityCheck
         raise ArgumentError, <<~ERROR
           vite-plugin-ruby@#{ npm_req } might not be compatible with vite_ruby-#{ ViteRuby::VERSION }
 
-          You may disable this check if needed: https://vite-ruby.netlify.app/config/#skipCompatibilityCheck
+          You may disable this check if needed: https://vite-ruby.netlify.app/config/#skipcompatibilitycheck
 
           You may upgrade both by running:
 

--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -70,6 +70,10 @@ class ViteRuby::Config
     ].freeze
   end
 
+  def ssr?
+    ARGV.any? { |arg| arg.include?('--ssr') || arg.include?('[ssr]') }
+  end
+
 private
 
   # Internal: Coerces all the configuration values, in case they were passed

--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -70,10 +70,6 @@ class ViteRuby::Config
     ].freeze
   end
 
-  def ssr?
-    ARGV.any? { |arg| arg.include?('--ssr') || arg.include?('[ssr]') }
-  end
-
 private
 
   # Internal: Coerces all the configuration values, in case they were passed
@@ -83,6 +79,7 @@ private
     config['port'] = config['port'].to_i
     config['root'] = Pathname.new(config['root'])
     config['build_cache_dir'] = config['root'].join(config['build_cache_dir'])
+    config['ssr_output_dir'] = config['root'].join(config['ssr_output_dir'])
     coerce_booleans(config, 'auto_build', 'hide_build_console_output', 'https', 'skip_compatibility_check')
   end
 


### PR DESCRIPTION
### Description 📖

This pull request is a follow-up to #210, which extends the support added in `vite-plugin-ruby` to the `vite_ruby` gem.

Now _Vite Ruby_ supports building your app in [SSR mode], obtaining a Node.js app
that can be used in combination with Rails, such as when using [Inertia.js in SSR mode][inertia-ssr].

When building in SSR mode, _Vite Ruby_ will use <kbd>[ssrEntrypoint]</kbd> as
the single entrypoint, and output the resulting app in a <kbd>[ssrOutputDir]/ssr.js</kbd> script.

The resulting Node.js script can be conveniently executed with <kbd>bin/vite ssr</kbd>.

### Background 📜

Some of the improvements that make this possible:

- Make SSR builds configurable: `ssrBuildEnabled`, `ssrEntrypoint`, and `ssrOutputDir`.
- Add `--ssr` support to the `build` command
- Use a separate cache file to track SSR builds to avoid having to use `--force`
- Clear the `ssrOutputDir` when running `vite clobber`

### Screenshots 📷 

![image](https://user-images.githubusercontent.com/1158253/168144504-5a4b92e0-b12a-42be-8d31-bf1ab17b90d5.png)
