### PR TITLE
Catch npm command not found, for folks who install deps with yarn

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -42,13 +42,8 @@ namespace :vite do
 
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
-    cmd = begin
-            `npm --version`.to_i < 7 ? 'npx ci --yes' : 'npx --yes ci'
-          # rescue if npm command is not installed to fallback
-          rescue Errno::ENOENT
-            'npx --yes ci'
-          end
-
+    legacy_flag = `npm --version`.to_i < 7 rescue false
+    cmd = legacy_flag ? 'npx ci --yes' : 'npx --yes ci'
     system({ 'NODE_ENV' => 'development' }, cmd)
   end
 

--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -42,7 +42,13 @@ namespace :vite do
 
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
-    cmd = `npm --version`.to_i < 7 ? 'npx ci --yes' : 'npx --yes ci'
+    cmd = begin
+            `npm --version`.to_i < 7 ? 'npx ci --yes' : 'npx --yes ci'
+          # rescue if npm command is not installed to fallback
+          rescue Errno::ENOENT
+            'npx --yes ci'
+          end
+
     system({ 'NODE_ENV' => 'development' }, cmd)
   end
 


### PR DESCRIPTION
### Description 📖

This pull request restores the previous behavior where the lack of npm and npx does not cause precompilation to raise.

### Background 📜

This behavior changed in https://github.com/ElMassimo/vite_ruby/commit/967fbf52aac5e52e1a059bffda79c7472874775f.

Previously, it was not necessary to have `npm` installed.

### The Fix 🔨

By changing the code to fallback on error, environments without `npm` will not get an error. 

Long term a better fix might be making pre-installation of dependencies optional for folks who manage their js dependencies using a tool other than npm.