### PR TITLE
Fix symbol error on vite_rails rake task `enhance` call

### DIFF
--- a/vite_rails/lib/tasks/vite.rake
+++ b/vite_rails/lib/tasks/vite.rake
@@ -2,4 +2,4 @@
 
 require 'vite_ruby'
 ViteRuby.install_tasks
-Rake::Task['vite:verify_install'].enhance(:environment) if Rake::Task.task_defined?(:environment)
+Rake::Task['vite:verify_install'].enhance([:environment]) if Rake::Task.task_defined?(:environment)


### PR DESCRIPTION
### Description 📖

Passing a symbol instead of an array into the `enhance` call will cause it to throw a type error

### Background 📜

I was calling `MyRailsApp::Application.load_tasks` from our `spec_helper.rb` file. This was loading Rails `vite.rake` with the `environment` task set, and triggering the error.

### The Fix 🔨

Changing to an array should work correctly with the code, it's not described very well in the Rake documentation unfortunately.
https://github.com/ruby/rake/blob/master/lib/rake/task.rb#L116

### Screenshots 📷
Here's a screenshot of the error in our CI build
<img width="703" alt="Screen Shot 2022-06-09 at 5 38 24 PM" src="https://user-images.githubusercontent.com/2158103/172967552-8fabe5df-1f05-422d-84ee-71691782de4e.png">

