### PR TITLE
Fix npm deprecation warning on assets:precompile

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -4,6 +4,8 @@ $stdout.sync = true
 
 require 'rake'
 
+legacy_npm_version = `npm --version`.to_i < 7 rescue false
+
 namespace :vite do
   task :binstubs do
     ViteRuby.commands.install_binstubs
@@ -42,8 +44,7 @@ namespace :vite do
 
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
-    legacy_flag = `npm --version`.to_i < 7 rescue false
-    cmd = legacy_flag ? 'npx ci --yes' : 'npx --yes ci'
+    cmd = legacy_npm_version ? 'npx ci --yes' : 'npx --yes ci'
     system({ 'NODE_ENV' => 'development' }, cmd)
   end
 
@@ -82,6 +83,10 @@ end
 
 # Any prerequisite task that installs packages should also install build dependencies.
 if ARGV.include?('assets:precompile')
-  ENV['NPM_CONFIG_PRODUCTION'] = 'false'
+  if legacy_npm_version
+    ENV['NPM_CONFIG_PRODUCTION'] = 'false'
+  else
+    ENV['NPM_CONFIG_INCLUDE'] = 'dev'
+  end
   ENV['YARN_PRODUCTION'] = 'false'
 end


### PR DESCRIPTION
### Description 📖

The vite_ruby rake file was setting `NPM_CONFIG_PRODUCTION=false`, which is deprecated. In recent versions of npm this causes a warning to be printed to the console.

```
npm WARN config production Use `--omit=dev` instead.
```

### The Fix 🔨

Fix by detecting the npm version and using `NPM_CONFIG_INCLUDE=dev` instead of `NPM_CONFIG_PRODUCTION=false` for npm 7+.

Ref: https://docs.npmjs.com/cli/v7/using-npm/config#include

### Screenshots 📷

Before:

```
$ bundle exec rake assets:precompile
npm WARN config production Use `--omit=dev` instead.
npm WARN config production Use `--omit=dev` instead.
yarn install v1.22.18
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.08s.
Skipping vite build. Watched files have not changed since the last build at 2022-07-09 13:09:30
```

After:

```
$ bundle exec rake assets:precompile
yarn install v1.22.18
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.09s.
Skipping vite build. Watched files have not changed since the last build at 2022-07-09 13:09:30
```

Fixes #220 