### PR TITLE
fix: use javascript_include_tag in vite_client_tag

### DIFF
--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -6,7 +6,7 @@ module ViteRails::TagHelpers
   def vite_client_tag
     return unless src = vite_manifest.vite_client_src
 
-    tag.script(src: src, type: 'module')
+    javascript_include_tag(src, type: 'module', extname: false)
   end
 
   # Public: Renders a script tag to enable HMR with React Refresh.


### PR DESCRIPTION
### Description 📖

In order to inherit all the features of the `javascript_include_tag` it should be used within `vite_client_tag`. Otherwise you won't get CSP support and all other built-in features.

### Background 📜

You won't be able to work with `vite_client_tag` in a CSP environment without this change.

### The Fix 🔨

Use `javascript_include_tag` instead of `tag.script`