### PR TITLE
fix: ensure rails app is initialized before inferring config

### DIFF
--- a/vite_rails/lib/tasks/vite.rake
+++ b/vite_rails/lib/tasks/vite.rake
@@ -2,4 +2,4 @@
 
 require 'vite_ruby'
 ViteRuby.install_tasks
-Rake::Task['vite:verify_install'].enhance([:environment]) if Rake::Task.task_defined?(:environment)
+Rake::Task['vite:verify_install'].enhance([:environment]) if Gem.loaded_specs['rails']

--- a/vite_rails/lib/vite_rails/config.rb
+++ b/vite_rails/lib/vite_rails/config.rb
@@ -1,15 +1,28 @@
 # frozen_string_literal: true
 
 module ViteRails::Config
+private
+
   # Override: Default values for a Rails application.
   def config_defaults
-    require 'rails'
+    ensure_rails_init
     asset_host = Rails.application&.config&.action_controller&.asset_host
     super(
       asset_host: asset_host.is_a?(Proc) ? nil : asset_host,
       mode: Rails.env.to_s,
       root: Rails.root || Dir.pwd,
     )
+  end
+
+  # Internal: Attempts to initialize the Rails application.
+  def ensure_rails_init
+    require File.expand_path('config/boot', Dir.pwd)
+    require File.expand_path('config/application', Dir.pwd)
+    unless Rails.application.initialized?
+      Rails.application.require_environment!
+    end
+  rescue StandardError, LoadError
+    require 'rails'
   end
 end
 


### PR DESCRIPTION
### Description 📖

This pull request ensures that when using `vite_rails` the parent Rails app is initialized before the config is resolved.

This ensures that it's safe to access Rails config values in `config/vite.rb`, and that settings like `asset_host` are always detected.

### Background 📜

This pull request is a follow-up to:

- https://github.com/ElMassimo/vite_ruby/issues/193

The [attempt to fix it](https://github.com/ElMassimo/vite_ruby/commit/72afbc7ab5ca33833e9330954499bcf460fd7669) only solved some situations, but does not work in all cases.

### The Fix 🔨

Explicitly requiring the application and initializing it ensures the config is available before running a build
