### PR TITLE
fix: prevent yarn 2+ error in `assets:precompile`

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -86,5 +86,8 @@ if ARGV.include?('assets:precompile')
   else
     ENV['NPM_CONFIG_INCLUDE'] = 'dev'
   end
-  ENV['YARN_PRODUCTION'] = 'false'
+
+  unless ViteRuby.commands.next_yarn?
+    ENV['YARN_PRODUCTION'] = 'false'
+  end
 end

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -71,6 +71,10 @@ class ViteRuby::Commands
     `npm --version`.to_i < 7 rescue false
   end
 
+  def next_yarn?
+    `yarn --version`.to_i >= 2 rescue false
+  end
+
   # Internal: Verifies if ViteRuby is properly installed.
   def verify_install
     unless File.exist?(config.root.join('bin/vite'))


### PR DESCRIPTION
### Description 📖

For Yarn 2+, `YARN_PRODUCTION=false` causes `Usage Error: Unrecognized or legacy configuration settings found: production - run "yarn config -v" to see the list of settings supported in Yarn (in <environment>)`

### Background 📜

Because there is no such global configuration for Yarn 2+, at least I have not found any similar on https://yarnpkg.com/configuration/yarnrc, we got the issue

### The Fix 🔨

Do not add env to prevent warning message if yarn version is more than `1`

### Screenshots 📷

![image](https://user-images.githubusercontent.com/125715/185936586-4c744b8d-92d1-41ac-b76b-a5c783e53e16.png)
