### PR TITLE
docs: document bug in safari that caches css and prevents hmr

### DIFF
--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -157,6 +157,10 @@ This is probably the case if you are seeing errors such as `#<Errno::EMFILE: Too
 
 Follow [this article][ulimit] for information on how to increase the limit of file descriptors in your OS.
 
+### CSS does not seem to reflect changes in dev
+
+Stylesheets are sent with [etags](https://en.wikipedia.org/wiki/HTTP_ETag) which allow a browser to cache the stylesheet until it changes. In development, a `Cache-Control: no-cache` header is also sent but unfortunately Safari does not respect the header and caches it anyways. The simplest way to work around the issue is to import the CSS directly into your javascript entry points. When the CSS is requested in this way it is requested with a query string that seems to break the cache.
+
 ## Fixed Issues
 
 ### Build not working in CI or Heroku


### PR DESCRIPTION
Discussed in [an issue](https://github.com/ElMassimo/vite_ruby/issues/258) opened the other day.

### Description 📖

Safari does not respect the combination of `ETag` and `Cache-Control: no-cache` headers without the use of a cache-busting query string. The `vite_stylesheet_tag` helper does not have this cache-busting query string but if you import the CSS directly into the JS, when it gets split out it works.

### Background 📜

Bug in Safari

### The Fix 🔨

We are documenting the behavior to help folks who may get stumped by it. In the issue, another option was linked in the comments as a workaround but that option didn't appear in my version of Safari and I wasn't able to work out how to disable cache. The only other option I've found so far is to manually empty the cache between stylesheet changes which is not a great dev experience.

### Screenshots 📷

Not relevant to this change, just light documentation adjustments.