### PR TITLE
fix(BREAKING CHANGE): lookup now returns nil if auto-build fails

### DIFF
--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 require 'open3'
 
 class BuilderTest < ViteRuby::Test
-  delegate :builder, to: 'ViteRuby.instance'
+  delegate :builder, :manifest, to: 'ViteRuby.instance'
 
   def last_build
     builder.last_build_metadata
@@ -44,6 +44,9 @@ class BuilderTest < ViteRuby::Test
       assert last_build.fresh?
       assert last_build.digest
       assert last_build.timestamp
+
+      refresh_config(auto_build: true)
+      refute_nil manifest.send(:lookup, 'app.css')
     }
   end
 
@@ -55,6 +58,9 @@ class BuilderTest < ViteRuby::Test
       assert last_build.fresh?
       assert last_build.digest
       assert last_build.timestamp
+
+      refresh_config(auto_build: true)
+      assert_nil manifest.send(:lookup, 'app.css')
     }
   end
 

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -78,7 +78,7 @@ protected
   #   manifest.lookup('calendar.js')
   #   => { "file" => "/vite/assets/calendar-1016838bab065ae1e122.js", "imports" => [] }
   def lookup(name, **options)
-    @build_mutex.synchronize { builder.build } if should_build?
+    @build_mutex.synchronize { builder.build || (return nil) } if should_build?
 
     find_manifest_entry resolve_entry_name(name, **options)
   end


### PR DESCRIPTION
### Description 📖

This pull request changes the behavior of `Manifest#lookup` when [`autoBuild`](https://vite-ruby.netlify.app/config/index.html#autobuild) is enabled.

It will now return `nil` if the last build has failed.

Closes #267.

### Background 📜

Previously, `lookup` would continue using the last generated manifest when available.

Although this allows a developer to continue working in the app after breaking the build, in practice most users will either:

- Prefer the app to break if the build fails, as logs for failing builds can be missed easily
- Have the Vite dev server running when making changes, in which case `autoBuild` is not used