### PR TITLE
Demo: What if autoBuild error could show you the actual build error message?

### DIFF
--- a/vite_ruby/lib/vite_ruby/build.rb
+++ b/vite_ruby/lib/vite_ruby/build.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'time'
 
 # Internal: Value object with information about the last build.
-ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current_digest, :last_build_path) do
+ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current_digest, :last_build_path, :err_msg) do
   # Internal: Combines information from a previous build with the current digest.
   def self.from_previous(last_build_path, current_digest)
     attrs = begin
@@ -21,6 +21,7 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current
       attrs['digest'] || 'none',
       current_digest,
       last_build_path,
+      attrs['err_msg'],
     )
   end
 
@@ -45,7 +46,7 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current
   end
 
   # Internal: Returns a new build with the specified result.
-  def with_result(success)
+  def with_result(success, err_msg=nil)
     self.class.new(
       success,
       Time.now.strftime('%F %T'),
@@ -53,6 +54,7 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current
       current_digest,
       current_digest,
       last_build_path,
+      err_msg,
     )
   end
 
@@ -68,6 +70,7 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current
       timestamp: timestamp,
       vite_ruby: vite_ruby,
       digest: digest,
+      err_msg: err_msg,
     )
   end
 end

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -14,7 +14,10 @@ class ViteRuby::Builder
     last_build = last_build_metadata(ssr: args.include?('--ssr'))
 
     if args.delete('--force') || last_build.stale?
-      build_with_vite(*args).tap { |success| record_build_metadata(success, last_build) }
+      build_with_vite(*args).yield_self do |success, err_msg|
+        record_build_metadata(success, last_build, err_msg)
+        success
+      end
     elsif last_build.success
       logger.debug "Skipping vite build. Watched files have not changed since the last build at #{ last_build.timestamp }"
       true
@@ -36,9 +39,9 @@ private
   def_delegators :@vite_ruby, :config, :logger, :run
 
   # Internal: Writes a digest of the watched files to disk for future checks.
-  def record_build_metadata(success, build)
+  def record_build_metadata(success, build, err_msg)
     config.build_cache_dir.mkpath
-    build.with_result(success).write_to_cache
+    build.with_result(success, err_msg).write_to_cache
   end
 
   # Internal: The file path where metadata of the last build is stored.
@@ -58,14 +61,16 @@ private
 
   # Public: Initiates a Vite build command to generate assets.
   #
-  # Returns true if the build is successful, or false if it failed.
+  # Returns a pair of:
+  # * success: true if the build is successful, or false if it failed.
+  # * err_msg: string with vite build errors in case of failure
   def build_with_vite(*args)
     logger.info 'Building with Vite ⚡️'
 
     stdout, stderr, status = run(['build', *args])
     log_build_result(stdout, stderr.to_s, status)
 
-    status.success?
+    [status.success?, stderr]
   end
 
   # Internal: Outputs the build results.

--- a/vite_ruby/lib/vite_ruby/missing_entrypoint_error.rb
+++ b/vite_ruby/lib/vite_ruby/missing_entrypoint_error.rb
@@ -22,7 +22,14 @@ class ViteRuby::MissingEntrypointError < ViteRuby::Error
   end
 
   def possible_causes(last_build)
-    return FAILED_BUILD_CAUSES.sub(':mode:', config.mode) if last_build.success == false
+    if last_build.success == false
+      str = FAILED_BUILD_CAUSES.sub(':mode:', config.mode)
+      if last_build.err_msg && ! last_build.err_msg.blank?
+        str += "\n#{last_build.err_msg.indent(4)}\n"
+      end
+      return str
+    end
+
     return DEFAULT_CAUSES if config.auto_build
 
     DEFAULT_CAUSES + NO_AUTO_BUILD_CAUSES


### PR DESCRIPTION
In autoBuild mode, when the entryPoint is missing (which includes the case of build failure), you already get an exception with a lengthy but very nice error message, constructed based on the actual state of the last build, that gives you context. It for instance does tell you, hey, the last build failed, that's probably why? When that's the situation. 

This is very nice! The developer ergonomics of vite and vite-ruby are really great. 

But what if that error message could actually include the vite build error too, for failed builds?  

It could if we store that error message along with the existing build metadata. 

This is really just a proof of concept for discussion, to see what you think, and cause I could.  It's definitely not done. It lacks tests, and does some probably not quite right things to code that need to be refactored. If you're not interested in this path, that's fine! 

One downside might be that by storing the error message in the metadata, you can end up with the error message being reproduced double, as the metadata is echo'd on scren. (And double in the console on _first_ build failure, once for the build failure itself, once for the exception message). 

Here's what it can end up looking like in Rails though, this sort of thing is really nice developer ergonomics in my opinion. 

![Screen Shot 2022-10-04 at 3 34 07 PM](https://user-images.githubusercontent.com/149304/193909521-87fd0fbf-b50b-469c-985f-1f9e67cfd534.png)
