### PR TITLE
feat: display last build errors in MissingEntrypointError

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
-    loofah (2.18.0)
+    loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     m (1.5.1)
@@ -109,7 +109,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.0.3)
     mini_portile2 (2.8.0)
-    minitest (5.16.2)
+    minitest (5.16.3)
     minitest-reporters (1.4.3)
       ansi
       builder
@@ -202,7 +202,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby

--- a/examples/rails/Rakefile
+++ b/examples/rails/Rakefile
@@ -10,6 +10,6 @@ Rails.application.load_tasks
 Rake::Task['assets:precompile'].enhance do |task|
   Dir.chdir(Rails.root.join('example_engine')) {
     _, stderr, status = ViteRuby::IO.capture("VITE_RUBY_VITE_BIN_PATH=#{Rails.root.join(ViteRuby.config.vite_bin_path)} bin/vite build")
-    raise stderr unless status.success?
+    raise stderr unless status
   }
 end

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -112,7 +112,7 @@ class BuilderTest < ViteRuby::Test
 private
 
   def stub_runner(success:, &block)
-    args = [:sterr, :stdout, OpenStruct.new(success?: success)]
+    args = ['stderr', 'stdout', success]
     ViteRuby::IO.stub(:capture, args, &block)
   end
 end

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -41,6 +41,7 @@ class BuilderTest < ViteRuby::Test
     stub_runner(success: true) {
       assert builder.build
       assert last_build.success
+      assert_empty last_build.errors
       assert last_build.fresh?
       assert last_build.digest
       assert last_build.timestamp
@@ -52,9 +53,11 @@ class BuilderTest < ViteRuby::Test
 
   def test_freshness_on_build_fail
     assert last_build.stale?
-    stub_runner(success: false) {
+    error_message = 'SyntaxError: Hero.jsx: Unexpected token (6:6)'
+    stub_runner(errors: error_message) {
       refute builder.build
       refute last_build.success
+      assert_equal last_build.errors, error_message
       assert last_build.fresh?
       assert last_build.digest
       assert last_build.timestamp
@@ -111,8 +114,8 @@ class BuilderTest < ViteRuby::Test
 
 private
 
-  def stub_runner(success:, &block)
-    args = ['stderr', 'stdout', success]
+  def stub_runner(errors: '', success: errors.empty?, &block)
+    args = ['stdout', errors, success]
     ViteRuby::IO.stub(:capture, args, &block)
   end
 end

--- a/test/engine_rake_tasks_test.rb
+++ b/test/engine_rake_tasks_test.rb
@@ -118,8 +118,8 @@ private
 
   def stub_runner(*args, **opts, &block)
     mock = Minitest::Mock.new
-    status = OpenStruct.new(success?: true)
-    mock.expect(:call, [:stdout, :stderr, status]) do |*argv, **options|
+    status = true
+    mock.expect(:call, ['stdout', 'stderr', status]) do |*argv, **options|
       assert_equal [args, opts].flatten.reject(&:blank?), (argv + [options]).flatten.reject(&:blank?)
     end
     ViteRuby.stub_any_instance(:run, ->(*stub_args, **stub_opts) { mock.call(*stub_args, **stub_opts) }, &block)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -83,7 +83,11 @@ class ManifestTest < ViteRuby::Test
   end
 
   def test_lookup_exception_when_build_failed
-    stub_builder(build_successful: false) {
+    error_lines = [
+      'SyntaxError: Hero.jsx: Unexpected token (6:6)',
+      '  4 |   return <>',
+    ]
+    stub_builder(build_successful: false, build_errors: error_lines.join("\n")) {
       asset_file = 'calendar.js'
 
       error = assert_raises_manifest_missing_entry_error do
@@ -92,6 +96,8 @@ class ManifestTest < ViteRuby::Test
 
       assert_match "Vite Ruby can't find entrypoints/#{ asset_file } in #{ manifest_path }", error.message
       assert_match 'The last build failed.', error.message
+      assert_match "  #{ error_lines[0] }", error.message
+      assert_match "  #{ error_lines[1] }", error.message
     }
   end
 

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -26,7 +26,7 @@ class RunnerTest < ViteRuby::Test
       stdout, stderr, status = ViteRuby.run(['"Hello"'])
       assert_equal %("Hello" --mode production\n), stdout
       assert_equal '', stderr
-      assert status.success?
+      assert status
     }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,11 +58,13 @@ class ViteRuby::Test < Minitest::Test
 
 private
 
-  def stub_builder(build_successful:, stale: false, &block)
+  def stub_builder(build_errors: '', build_successful: build_errors.empty?, stale: false, &block)
     ViteRuby::Build.stub_any_instance(:success, build_successful) {
       ViteRuby::Build.stub_any_instance(:stale?, stale) {
-        result = ['stderr', 'stdout', build_successful]
-        ViteRuby::Builder.stub_any_instance(:build_with_vite, result, &block)
+        ViteRuby::Build.stub_any_instance(:errors, build_errors) {
+          result = ['stdout', build_errors, build_successful]
+          ViteRuby::Builder.stub_any_instance(:build_with_vite, result, &block)
+        }
       }
     }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,7 +61,8 @@ private
   def stub_builder(build_successful:, stale: false, &block)
     ViteRuby::Build.stub_any_instance(:success, build_successful) {
       ViteRuby::Build.stub_any_instance(:stale?, stale) {
-        ViteRuby::Builder.stub_any_instance(:build_with_vite, build_successful, &block)
+        result = ['stderr', 'stdout', build_successful]
+        ViteRuby::Builder.stub_any_instance(:build_with_vite, result, &block)
       }
     }
   end

--- a/vite_ruby/lib/vite_ruby/build.rb
+++ b/vite_ruby/lib/vite_ruby/build.rb
@@ -18,10 +18,10 @@ ViteRuby::Build = Struct.new(:success, :timestamp, :vite_ruby, :digest, :current
   private
 
     # Internal: Reads metadata recorded on the last build, if it exists.
-    def parse_metadata(_path)
-      return default_metadata unless last_build_path.exist?
+    def parse_metadata(pathname)
+      return default_metadata unless pathname.exist?
 
-      JSON.parse(last_build_path.read.to_s).transform_keys(&:to_sym)
+      JSON.parse(pathname.read.to_s).transform_keys(&:to_sym)
     rescue JSON::JSONError, Errno::ENOENT, Errno::ENOTDIR
       default_metadata
     end

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -14,7 +14,10 @@ class ViteRuby::Builder
     last_build = last_build_metadata(ssr: args.include?('--ssr'))
 
     if args.delete('--force') || last_build.stale?
-      build_with_vite(*args).tap { |success| record_build_metadata(success, last_build) }
+      stdout, stderr, success = build_with_vite(*args)
+      log_build_result(stdout, stderr, success)
+      record_build_metadata(last_build, errors: stderr, success: success)
+      success
     elsif last_build.success
       logger.debug "Skipping vite build. Watched files have not changed since the last build at #{ last_build.timestamp }"
       true
@@ -36,9 +39,9 @@ private
   def_delegators :@vite_ruby, :config, :logger, :run
 
   # Internal: Writes a digest of the watched files to disk for future checks.
-  def record_build_metadata(success, build)
+  def record_build_metadata(build, **attrs)
     config.build_cache_dir.mkpath
-    build.with_result(success).write_to_cache
+    build.with_result(**attrs).write_to_cache
   end
 
   # Internal: The file path where metadata of the last build is stored.
@@ -57,24 +60,19 @@ private
   end
 
   # Public: Initiates a Vite build command to generate assets.
-  #
-  # Returns true if the build is successful, or false if it failed.
   def build_with_vite(*args)
     logger.info 'Building with Vite ⚡️'
 
-    stdout, stderr, status = run(['build', *args])
-    log_build_result(stdout, stderr.to_s, status)
-
-    status.success?
+    run(['build', *args])
   end
 
   # Internal: Outputs the build results.
   #
   # NOTE: By default it also outputs the manifest entries.
   def log_build_result(_stdout, stderr, status)
-    if status.success?
+    if status
       logger.info "Build with Vite complete: #{ config.build_output_dir }"
-      logger.error stderr.to_s unless stderr.empty?
+      logger.error stderr unless stderr.empty?
     else
       logger.error stderr
       logger.error 'Build with Vite failed! ❌'

--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -111,7 +111,7 @@ private
   def run_with_capture(*args, **options)
     Dir.chdir(root) do
       _, stderr, status = ViteRuby::IO.capture(*args, **options)
-      say(stderr) unless status.success? || stderr.to_s.empty?
+      say(stderr) unless status || stderr.empty?
     end
   end
 

--- a/vite_ruby/lib/vite_ruby/io.rb
+++ b/vite_ruby/lib/vite_ruby/io.rb
@@ -15,7 +15,7 @@ module ViteRuby::IO
         stdin.close
         out = Thread.new { read_lines(stdout, &with_output) }
         err = Thread.new { stderr.read }
-        [out.value, err.value, wait_threads.value]
+        [out.value, err.value.to_s, wait_threads.value.success?]
       }
     end
 

--- a/vite_ruby/lib/vite_ruby/missing_entrypoint_error.rb
+++ b/vite_ruby/lib/vite_ruby/missing_entrypoint_error.rb
@@ -17,19 +17,25 @@ class ViteRuby::MissingEntrypointError < ViteRuby::Error
       #{ possible_causes(last_build) }
       :troubleshooting:
       #{ "\nContent in your manifests:\n#{ JSON.pretty_generate(manifest) }\n" if last_build.success }
-      #{ "Last build in #{ config.mode } mode:\n#{ last_build.to_json }\n" unless last_build.success.nil? }
+      #{ "Last build in #{ config.mode } mode:\n#{ last_build.to_json }\n" if last_build.success }
     MSG
   end
 
   def possible_causes(last_build)
-    return FAILED_BUILD_CAUSES.sub(':mode:', config.mode) if last_build.success == false
-    return DEFAULT_CAUSES if config.auto_build
-
-    DEFAULT_CAUSES + NO_AUTO_BUILD_CAUSES
+    if last_build.success == false
+      FAILED_BUILD_CAUSES
+        .sub(':mode:', config.mode)
+        .sub(':errors:', last_build.errors.to_s.gsub(/^(?!$)/, '    '))
+    elsif config.auto_build
+      DEFAULT_CAUSES
+    else
+      DEFAULT_CAUSES + NO_AUTO_BUILD_CAUSES
+    end
   end
 
   FAILED_BUILD_CAUSES = <<-MSG
   - The last build failed. Try running `bin/vite build --clear --mode=:mode:` manually and check for errors.
+  :errors:
   MSG
 
   DEFAULT_CAUSES = <<-MSG

--- a/vite_ruby/lib/vite_ruby/missing_entrypoint_error.rb
+++ b/vite_ruby/lib/vite_ruby/missing_entrypoint_error.rb
@@ -25,7 +25,7 @@ class ViteRuby::MissingEntrypointError < ViteRuby::Error
     if last_build.success == false
       FAILED_BUILD_CAUSES
         .sub(':mode:', config.mode)
-        .sub(':errors:', last_build.errors.to_s.gsub(/^(?!$)/, '    '))
+        .sub(':errors:', last_build.errors.to_s.gsub(/^(?!$)/, '  '))
     elsif config.auto_build
       DEFAULT_CAUSES
     else
@@ -33,9 +33,11 @@ class ViteRuby::MissingEntrypointError < ViteRuby::Error
     end
   end
 
-  FAILED_BUILD_CAUSES = <<-MSG
-  - The last build failed. Try running `bin/vite build --clear --mode=:mode:` manually and check for errors.
-  :errors:
+  FAILED_BUILD_CAUSES = <<~MSG
+      - The last build failed. Try running `bin/vite build --clear --mode=:mode:` manually and check for errors.
+
+    Errors:
+    :errors:
   MSG
 
   DEFAULT_CAUSES = <<-MSG

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/ElMassimo/vite_ruby/blob/vite_ruby@#{ ViteRuby::VERSION }/vite_ruby/CHANGELOG.md",
   }
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.4')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   s.add_dependency 'dry-cli', '~> 0.7.0'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'


### PR DESCRIPTION
### Description 📖

This pull request implements the proposal in #269, to display build errors as part of the `ViteRuby::MissingEntrypointError` error message.

This is a nice improvement in UX, as users could now understand the problem without having to manually trigger a build.

Thanks for the suggestion @jrochkind! 😃 

### Screenshots 📷

#### Before

<img width="789" alt="Screen Shot 2022-10-07 at 19 10 05" src="https://user-images.githubusercontent.com/1158253/194669571-0e7c34e5-4277-490b-b597-aa038581b5d7.png">

#### After

<img width="921" alt="Screen Shot 2022-10-07 at 18 39 53" src="https://user-images.githubusercontent.com/1158253/194669285-4ab0f8ee-872a-4e82-a8fe-f13dc8ed0076.png">
