### PR TITLE
fix: yarn berry pnp mode support

### DIFF
--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -71,9 +71,19 @@ class ViteRuby::Commands
     `npm --version`.to_i < 7 rescue false
   end
 
+  # Internal: Checks if the package manager is yarn.
+  def yarn?
+    config.root.join('yarn.lock').exist?
+  end
+
   # Internal: Checks if the yarn version is 1.x.
   def legacy_yarn_version?
     `yarn --version`.to_i < 2 rescue false
+  end
+
+  # Internal: Checks if the package manager is yarn and the version is berry.
+  def yarn_berry?
+    yarn? && !legacy_yarn_version?
   end
 
   # Internal: Verifies if ViteRuby is properly installed.

--- a/vite_ruby/lib/vite_ruby/runner.rb
+++ b/vite_ruby/lib/vite_ruby/runner.rb
@@ -31,7 +31,11 @@ private
       args = args.clone
       cmd.push('node', '--inspect-brk') if args.delete('--inspect')
       cmd.push('node', '--trace-deprecation') if args.delete('--trace_deprecation')
-      cmd.push(vite_executable)
+      if ViteRuby.commands.yarn_berry?
+        cmd.push('yarn', 'vite')
+      else
+        cmd.push(vite_executable)
+      end
       cmd.push(*args)
       cmd.push('--mode', config.mode) unless args.include?('--mode') || args.include?('-m')
     end


### PR DESCRIPTION
---

Thank you for this wonderful gem! I really love it ❤️ 

### Description 📖

This pull request supports yarn berry's pnp mode.

### Background 📜

When I used vite-ruby with yarn berry pnp mode, there was an error about `bin/vite dev`. You can reproduce it in this repository. https://github.com/heka1024/yarn_berry_vite. The problem was `vite_ruby` looked up `node_modules/.bin/vite` but there wasn't `node_modules`.

### The Fix 🔨

By changing `vite_ruby/lib/vite_ruby/runner.rb` to use `yarn` instead of `node_modules/.bin/vite`, we can now use the zero install mode of yarn berry. 😃 

I think 
```ruby
if ViteRuby.commands.yarn_berry?
  cmd.push('yarn', 'vite')
else
  cmd.push(vite_executable)
end
```
this is ugly, but I can't imagine a better one. I'd appreciate it if you could suggest a better way.

