### PR TITLE
feat: output exit code when vite process fails

### DIFF
--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -115,7 +115,7 @@ class BuilderTest < ViteRuby::Test
 private
 
   def stub_runner(errors: '', success: errors.empty?, &block)
-    args = ['stdout', errors, success]
+    args = ['stdout', errors, MockProcessStatus.new(success: success)]
     ViteRuby::IO.stub(:capture, args, &block)
   end
 end

--- a/test/engine_rake_tasks_test.rb
+++ b/test/engine_rake_tasks_test.rb
@@ -118,7 +118,7 @@ private
 
   def stub_runner(*args, **opts, &block)
     mock = Minitest::Mock.new
-    status = true
+    status = MockProcessStatus.new
     mock.expect(:call, ['stdout', 'stderr', status]) do |*argv, **options|
       assert_equal [args, opts].flatten.reject(&:blank?), (argv + [options]).flatten.reject(&:blank?)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,7 @@ private
     ViteRuby::Build.stub_any_instance(:success, build_successful) {
       ViteRuby::Build.stub_any_instance(:stale?, stale) {
         ViteRuby::Build.stub_any_instance(:errors, build_errors) {
-          result = ['stdout', build_errors, build_successful]
+          result = ['stdout', build_errors, MockProcessStatus.new(success: build_successful)]
           ViteRuby::Builder.stub_any_instance(:build_with_vite, result, &block)
         }
       }
@@ -83,5 +83,15 @@ private
         mock.verify
       end
     }
+  end
+
+  class MockProcessStatus
+    def initialize(success: true)
+      @success = success
+    end
+
+    def success?
+      @success
+    end
   end
 end

--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -111,7 +111,7 @@ private
   def run_with_capture(*args, **options)
     Dir.chdir(root) do
       _, stderr, status = ViteRuby::IO.capture(*args, **options)
-      say(stderr) unless status || stderr.empty?
+      say(stderr) unless status.success? || stderr.empty?
     end
   end
 

--- a/vite_ruby/lib/vite_ruby/io.rb
+++ b/vite_ruby/lib/vite_ruby/io.rb
@@ -15,7 +15,7 @@ module ViteRuby::IO
         stdin.close
         out = Thread.new { read_lines(stdout, &with_output) }
         err = Thread.new { stderr.read }
-        [out.value, err.value.to_s, wait_threads.value.success?]
+        [out.value, err.value.to_s, wait_threads.value]
       }
     end
 


### PR DESCRIPTION
The process can fail without output to stderr in some cases, like if it was killed. This is confusing because the build says it failed with no reason why. Now, output the status of the command on any failure.

Before:
```
Building with Vite ⚡️
vite v3.2.2 building for test...
transforming...

Build with Vite failed! ❌
```

Now:
```
Building with Vite ⚡️
vite v3.2.2 building for test...
transforming...

pid 869500 SIGKILL (signal 9)
Build with Vite failed! ❌
```

Closes #292.