### PR TITLE
fix: avoid removing double extension for non-preprocessor assets

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,16 +17,19 @@ jobs:
           "3.1",
         ]
         gemfile: [
-          "gemfiles/Gemfile-rails.6.0.x",
-          "gemfiles/Gemfile-rails.6.1.x",
-          "gemfiles/Gemfile-rails.7.0.x"
+          "Gemfile-rails.6.0.x",
+          "Gemfile-rails.6.1.x",
+          "Gemfile-rails.7.0.x"
         ]
         experimental: [false]
         include:
           - ruby: "3.1"
             os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails-edge
+            gemfile: Gemfile-rails-edge
             experimental: true
+
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}
 
     steps:
       - uses: actions/checkout@v3

--- a/test/dev_server_proxy_test.rb
+++ b/test/dev_server_proxy_test.rb
@@ -80,6 +80,11 @@ class DevServerProxyTest < ViteRuby::Test
     assert_forwarded to: '/vite-production/entrypoints/sassy.scss'
   end
 
+  def test_stylus_with_extra_css
+    get_with_dev_server_running '/vite-production/entrypoints/sassy.stylus.css'
+    assert_forwarded to: '/vite-production/entrypoints/sassy.stylus'
+  end
+
   def test_min_css
     get_with_dev_server_running '/vite-production/colored.min.css'
     assert_forwarded to: '/vite-production/colored.min.css'
@@ -88,6 +93,11 @@ class DevServerProxyTest < ViteRuby::Test
   def test_module_css
     get_with_dev_server_running '/vite-production/colored.module.css'
     assert_forwarded to: '/vite-production/colored.module.css'
+  end
+
+  def test_random_extension_css
+    get_with_dev_server_running '/vite-production/colored.bubble.css'
+    assert_forwarded to: '/vite-production/colored.bubble.css'
   end
 
   def test_without_dev_server_running

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -93,7 +93,11 @@ class HelperTest < HelperTestCase
     with_dev_server_running {
       assert_similar link(href: '/vite-dev/entrypoints/app.css'), vite_stylesheet_tag('app')
       assert_equal vite_stylesheet_tag('app'), vite_stylesheet_tag('app.css')
-      assert_similar link(href: '/vite-dev/entrypoints/sassy.scss.css'), vite_stylesheet_tag('sassy.scss')
+      if Rails::VERSION::MAJOR >= 7
+        assert_similar link(href: '/vite-dev/entrypoints/sassy.scss'), vite_stylesheet_tag('sassy.scss')
+      else
+        assert_similar link(href: '/vite-dev/entrypoints/sassy.scss.css'), vite_stylesheet_tag('sassy.scss')
+      end
     }
   end
 

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -42,7 +42,11 @@ module ViteRails::TagHelpers
     entries = vite_manifest.resolve_entries(*names, type: asset_type)
     tags = javascript_include_tag(*entries.fetch(:scripts), crossorigin: crossorigin, type: type, extname: false, **options)
     tags << vite_preload_tag(*entries.fetch(:imports), crossorigin: crossorigin, **options) unless skip_preload_tags
+
+    options[:extname] = false if Rails::VERSION::MAJOR >= 7
+
     tags << stylesheet_link_tag(*entries.fetch(:stylesheets), media: media, **options) unless skip_style_tags
+
     tags
   end
 
@@ -54,6 +58,9 @@ module ViteRails::TagHelpers
   # Public: Renders a <link> tag for the specified Vite entrypoints.
   def vite_stylesheet_tag(*names, **options)
     style_paths = names.map { |name| vite_asset_path(name, type: :stylesheet) }
+
+    options[:extname] = false if Rails::VERSION::MAJOR >= 7
+
     stylesheet_link_tag(*style_paths, **options)
   end
 

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -38,7 +38,7 @@ private
     uri
       .sub(HOST_WITH_PORT_REGEX, '/') # Hanami adds the host and port.
       .sub('.ts.js', '.ts') # Hanami's javascript helper always adds the extension.
-      .sub(/(\.(?!min|module)\w+)\.css$/, '\1') # Rails' stylesheet_link_tag always adds the extension.
+      .sub(/\.(sass|scss|styl|stylus|less|pcss|postcss)\.css$/, '.\1') # Rails' stylesheet_link_tag always adds the extension.
   end
 
   def forward_to_vite_dev_server(env)


### PR DESCRIPTION
### Description 📖

This pull request makes some changes to ensure CSS filenames such as `jquery.tree.css` are not converted to `jquery.tree` in the `ViteRuby::DevServerProxy`.

### Background 📜

Historically, `stylesheet_link_tag` in Rails did not support passing `extname` to `asset_path`, causing it to always append `.css` to any provided filenames.

This is problematic in Vite, because the dev server _can_ serve `file.scss`.

For that reason, the `DevServerProxy` needed to convert that `file.scss.css` to `file.css`.

Since it's very uncommon for CSS files to have two extensions, the naive approach of removing the extra `.css` hasn't been a problem in practice, until #300.

### The Fix 🔨

Restricting this patch to files with a known CSS preprocessor extension. The regex is more verbose, but should cause less problems.

In addition, [support for `extname` was added in Rails 7](https://github.com/rails/rails/pull/41927), so in the future it will be possible to stop using this patch in the proxy.
