### PR TITLE
perf: avoid calculating digest on each lookup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.4)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -85,7 +85,7 @@ class ViteRuby
   # NOTE: Checks only once every second since every lookup calls this method.
   def dev_server_running?
     return false unless run_proxy?
-    return true if defined?(@running_at) && @running_at && Time.now - @running_at < 1
+    return true if @running_at && Time.now - @running_at < 1
 
     Socket.tcp(config.host, config.port, connect_timeout: config.dev_server_connect_timeout).close
     @running_at = Time.now

--- a/vite_ruby/lib/vite_ruby/builder.rb
+++ b/vite_ruby/lib/vite_ruby/builder.rb
@@ -52,10 +52,13 @@ private
   # Internal: Returns a digest of all the watched files, allowing to detect
   # changes, and skip Vite builds if no files have changed.
   def watched_files_digest
+    return @last_digest if @last_digest_at && Time.now - @last_digest_at < 1
+
     config.within_root do
       files = Dir[*config.watched_paths].reject { |f| File.directory?(f) }
       file_ids = files.sort.map { |f| "#{ File.basename(f) }/#{ Digest::SHA1.file(f).hexdigest }" }
-      Digest::SHA1.hexdigest(file_ids.join('/'))
+      @last_digest_at = Time.now
+      @last_digest = Digest::SHA1.hexdigest(file_ids.join('/'))
     end
   end
 


### PR DESCRIPTION
### Description 📖

This pull request adds caching to `watched_files_digest`,  using the same technique as in [`dev_server_running?`](https://github.com/ElMassimo/vite_ruby/blame/7f2f9eeada757039b73bf15475bdcae0ce3932b6/vite_ruby/lib/vite_ruby.rb).

The result will be cached for a second, before recalculating.

### Background 📜

In development, each `lookup` will call `build`, checking whether files have changed since the last build.

Most of the time, pages have a single `vite_typescript_tag`, doing a single lookup.

However, in pages that link many assets using `vite_asset_path` or `vite_image_path`, calculating the digest each time can be very time consuming.

### The Fix 🔨

By caching the result, on a normal request lifecycle the digest will only be calculated once, preventing the performance degradation.