### PR TITLE
feat: add experimental `skipProxy` setting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   rules: {
     'react/react-in-jsx-scope': 'off',
     'import/named': 'off',
+    'no-prototype-builtins': 'off',
   },
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.4)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -11,6 +11,7 @@
 [watchAdditionalPaths]: /config/#watchadditionalpaths
 [publicDir]: /config/#publicdir
 [root]: /config/#root
+[https]: /config/#https
 [alignment with Rails defaults]: https://github.com/rails/webpacker/issues/769
 [source maps]: https://vitejs.dev/config/#build-sourcemap
 [import aliases]: /guide/development.html#import-aliases-👉
@@ -313,6 +314,20 @@ You can customize this behavior using the following options.
   version, which should resolve this error.
 
   Otherwise, this setting allows to skip that check. Use it responsibly.
+
+### skipProxy (experimental)
+
+- **Version Added:** `3.2.12`
+- **Default:** `false`
+- **Env Var:** `VITE_RUBY_SKIP_PROXY`
+
+  Whether to skip the [dev server proxy](/overview#in-development), and request assets to the Vite
+  development server directly.
+
+  Connecting to Vite directly allows assets to be served using HTTP2 when <kbd>[https]</kbd> is enabled.
+
+  Don't enable this option in Rails 6 or earlier if you are using `vite_stylesheet_tag` with assets that don't have a `.css` extension,
+  [or Vite will fail to serve them](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/dev_server_proxy.rb#L41).
 
 ### viteBinPath
 

--- a/vite-plugin-ruby/default.vite.json
+++ b/vite-plugin-ruby/default.vite.json
@@ -11,6 +11,7 @@
   "entrypointsDir": "entrypoints",
   "sourceCodeDir": "app/frontend",
   "skipCompatibilityCheck": false,
+  "skipProxy": false,
   "host": "localhost",
   "https": null,
   "port": 3036,

--- a/vite-plugin-ruby/src/config.ts
+++ b/vite-plugin-ruby/src/config.ts
@@ -86,6 +86,9 @@ function coerceConfigurationValues (config: ResolvedConfig, projectRoot: string,
 
   const server: ServerOptions = { fs, host: config.host, https, port, strictPort: true }
 
+  if (booleanOption(config.skipProxy))
+    server.origin = `${https ? 'https' : 'http'}://${config.host}:${config.port}`
+
   // Connect directly to the Vite dev server, rack-proxy does not proxy websocket connections.
   const hmr = userConfig.server?.hmr ?? {}
   if (typeof hmr === 'object' && !hmr.hasOwnProperty('clientPort')) {

--- a/vite-plugin-ruby/src/types.ts
+++ b/vite-plugin-ruby/src/types.ts
@@ -17,6 +17,7 @@ export interface ResolvedConfig {
   publicOutputDir: string
   watchAdditionalPaths: string[]
   base: string
+  skipProxy: boolean
   /**
    * @private
    * In the context of the internal code, whether an SSR build should be performed.

--- a/vite_ruby/default.vite.json
+++ b/vite_ruby/default.vite.json
@@ -11,6 +11,7 @@
   "entrypointsDir": "entrypoints",
   "sourceCodeDir": "app/frontend",
   "skipCompatibilityCheck": false,
+  "skipProxy": false,
   "host": "localhost",
   "https": null,
   "port": 3036,

--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -5,6 +5,10 @@ require 'json'
 # Public: Allows to resolve configuration sourced from `config/vite.json` and
 # environment variables, combining them with the default options.
 class ViteRuby::Config
+  def origin
+    "#{ protocol }://#{ host_with_port }"
+  end
+
   def protocol
     https ? 'https' : 'http'
   end
@@ -90,7 +94,7 @@ private
     config['root'] = Pathname.new(config['root'])
     config['build_cache_dir'] = config['root'].join(config['build_cache_dir'])
     config['ssr_output_dir'] = config['root'].join(config['ssr_output_dir'])
-    coerce_booleans(config, 'auto_build', 'hide_build_console_output', 'https', 'skip_compatibility_check')
+    coerce_booleans(config, 'auto_build', 'hide_build_console_output', 'https', 'skip_compatibility_check', 'skip_proxy')
   end
 
   # Internal: Coerces configuration options to boolean.

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -125,13 +125,18 @@ private
 
   # Internal: Scopes an asset to the output folder in public, as a path.
   def prefix_vite_asset(path)
-    File.join("/#{ config.public_output_dir }", path)
+    File.join(vite_asset_origin || '/', config.public_output_dir, path)
   end
 
   # Internal: Prefixes an asset with the `asset_host` for tags that do not use
   # the framework tag helpers.
   def prefix_asset_with_host(path)
-    File.join(config.asset_host || '/', config.public_output_dir, path)
+    File.join(vite_asset_origin || config.asset_host || '/', config.public_output_dir, path)
+  end
+
+  # Internal: The origin of assets managed by Vite.
+  def vite_asset_origin
+    config.origin if dev_server_running? && config.skip_proxy
   end
 
   # Internal: Resolves the paths that reference a manifest entry.


### PR DESCRIPTION
### Description 📖

This pull request adds an experimental `skipProxy` setting.

### Spec 📜

Whether to skip the [dev server proxy](https://vite-ruby.netlify.app/overview.html#in-development), and request assets to the Vite development server directly.

Connecting to Vite directly allows assets to be served using HTTP2 when [`https`](http://localhost:3005/config/index.html#https) is enabled.

Don't enable this option in Rails 6 or earlier if you are using `vite_stylesheet_tag` with assets that don't have a `.css` extension, [or Vite will fail to serve them](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/dev_server_proxy.rb#L41).
