### PR TITLE
Fix compatibility with react-refresh-swc, which doesn't provide a default export

### DIFF
--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -51,8 +51,8 @@ class ViteRuby::Manifest
     if dev_server_running?
       <<~REACT_REFRESH
         <script type="module">
-          import RefreshRuntime from '#{ prefix_asset_with_host('@react-refresh') }'
-          RefreshRuntime.injectIntoGlobalHook(window)
+          import { injectIntoGlobalHook } from '#{ prefix_asset_with_host('@react-refresh') }'
+          injectIntoGlobalHook(window)
           window.$RefreshReg$ = () => {}
           window.$RefreshSig$ = () => (type) => type
           window.__vite_plugin_react_preamble_installed__ = true


### PR DESCRIPTION
### Description 📖

Vite 4 includes [support for react-refresh-swc](https://vitejs.dev/blog/announcing-vite4.html#new-react-plugin-using-swc-during-development), which replaces Babel with SWC for even faster hot reloads. However, unlike `react-refresh`, it doesn't provide a default export. Thus, it's necessary to directly import `injectIntoGlobalHook` and call it rather than importing defaults as `RefreshRuntime`

See the plugin's preamble implementation:

https://github.com/vitejs/vite-plugin-react-swc/blob/00fe7e406f0a7568ee7aabb3c65e6debdc8e8bd3/src/index.ts#L10-L13

### The Fix 🔨

We just directly import injectIntoGlobalHook rather than importing the whole module.