### PR TITLE
chore: bump dry-cli version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
   remote: vite_ruby
   specs:
     vite_ruby (3.2.13)
-      dry-cli (~> 0.7.0)
+      dry-cli (~> 1.0)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
 
@@ -90,7 +90,7 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     docile (1.3.5)
-    dry-cli (0.7.0)
+    dry-cli (1.0.0)
     erubi (1.11.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
   remote: vite_ruby
   specs:
     vite_ruby (3.2.13)
-      dry-cli (~> 1.0)
+      dry-cli (>= 0.7, < 2)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
 

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
-  s.add_dependency 'dry-cli', '~> 0.7.0'
+  s.add_dependency 'dry-cli', '~> 1.0'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'
   s.add_dependency 'zeitwerk', '~> 2.2'
 

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
-  s.add_dependency 'dry-cli', '~> 1.0'
+  s.add_dependency 'dry-cli', '>= 0.7', '< 2'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'
   s.add_dependency 'zeitwerk', '~> 2.2'
 


### PR DESCRIPTION
### Description 📖

Hello!
Could we bump `dry-cli` dependency version to `1.0.x`? Looks like no breaking changes from `~0.7`