### PR TITLE
feat: allow javascript_include_tag options to vite_client_tag

### DIFF
--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -3,10 +3,10 @@
 # Public: Allows to render HTML tags for scripts and styles processed by Vite.
 module ViteRails::TagHelpers
   # Public: Renders a script tag for vite/client to enable HMR in development.
-  def vite_client_tag
+  def vite_client_tag(**options)
     return unless src = vite_manifest.vite_client_src
 
-    javascript_include_tag(src, type: 'module', extname: false)
+    javascript_include_tag(src, type: 'module', extname: false, **options)
   end
 
   # Public: Renders a script tag to enable HMR with React Refresh.


### PR DESCRIPTION
### Description 📖

This allows passing options such as `nonce`, which some browsers require if CSP is set (Firefox).

### Background 📜

With CSP set in Rails, Firefox would fail to load the vite client tag without a `nonce` set.

### The Fix 🔨

`vite_client_tag` now accepts an `options` hash that is passed to `javascript_include_tag`, much like `vite_javascript_tag`.

Co-authored-by: Wil Hall <wil@wilhall.com>