### PR TITLE
feat: install dependencies with yarn if npx is not available

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -43,7 +43,10 @@ namespace :vite do
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
     cmd = ViteRuby.commands.legacy_npm_version? ? 'npx ci --yes' : 'npx --yes ci'
-    system({ 'NODE_ENV' => 'development' }, cmd)
+    result = system({ 'NODE_ENV' => 'development' }, cmd)
+
+    # Fallback to `yarn` if `npx` is not available.
+    system({ 'NODE_ENV' => 'development' }, 'yarn install --frozen-lockfile') if result.nil?
   end
 
   desc "Provide information on ViteRuby's environment"


### PR DESCRIPTION
### Description 📖

This pull request closes:

- #342 

Vite Ruby will now try to install dependencies with `yarn` in systems where `npx` is not available.

### Background 📜

Given how Rails forced users to rely on `yarn` when using `webpacker`, and to this day ships with a `yarn:install` task, it's not unusual that certain container or buildpacks include `yarn` but not `npm`.

As a result, in those deployment setups `npx` might not be available, for example, in the Heroku Ruby buildpack.