### PR TITLE
chore: update dockerfile for the rails example

### DIFF
--- a/examples/rails/Dockerfile
+++ b/examples/rails/Dockerfile
@@ -1,12 +1,17 @@
 FROM ruby:3.0 AS builder
 
 # Install nodejs in the ruby image
-RUN curl -sL https://deb.nodesource.com/setup_15.x | bash - && apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 RUN npm install -g yarn
 
 # Gems and packages will be cached in a separate image using a mounted volume.
 ENV BUNDLE_PATH /bundler_cache
 ENV YARN_CACHE_FOLDER /yarn_cache
+ENV BUNDLER_VERSION 2.3.22
+
+# Match the version of Bundler with that specified in Gemfile.lock
+RUN gem update --system \
+    && gem install bundler -v $BUNDLER_VERSION
 
 # Set working directory inside the image home.
 ENV APP_PATH /app


### PR DESCRIPTION
### Description 📖
This pull request addresses two issues found in the examples directory's Rails project.

### Background 📜
1. The Node version specified in package.json was set to 16, while the Node version in the Rails Dockerfile was 15.14.0. This inconsistency caused the following error message:

```
vite_1   | yarn install v1.22.19
vite_1   | info No lockfile found.
vite_1   | [1/5] Validating package.json...
vite_1   | error blog@0.1.0: The engine "node" is incompatible with this module. Expected version "16". Got "15.14.0"
vite_1   | warning blog@0.1.0: The engine "pnpm" appears to be invalid.
vite_1   | info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
vite_1   | error Found incompatible module.
rails_vite_1 exited with code 1
```

https://github.com/ElMassimo/vite_ruby/blob/ff7df1bb9c37f66625003c84439eef600a9ffb85/examples/rails/package.json#L9-L12
https://github.com/ElMassimo/vite_ruby/blob/ff7df1bb9c37f66625003c84439eef600a9ffb85/examples/rails/Dockerfile#L4

2. The bundler version inside the Ruby image is older than the version that created the lockfile. This resulted in the following error message:

```
vite_1   | Activating bundler (~> 2.3) failed:
vite_1   | Could not find 'bundler' (2.3.22) required by your /app/Gemfile.lock.
vite_1   | To update to the latest version installed on your system, run `bundle update --bundler`.
vite_1   | To install the missing version, run `gem install bundler:2.3.22`
vite_1   | Checked in 'GEM_PATH=/root/.local/share/gem/ruby/3.0.0:/usr/local/lib/ruby/gems/3.0.0:/usr/local/bundle' , execute `gem env` for more information
vite_1   | 
vite_1   | To install the version of bundler this project requires, run `gem install bundler -v '~> 2.3'`
```

```
Warning: the running version of Bundler (2.2.33) is older than the version that created the lockfile (2.3.22). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.22`.
```

https://github.com/ElMassimo/vite_ruby/blob/ff7df1bb9c37f66625003c84439eef600a9ffb85/examples/rails/Gemfile.lock#L281-L282

### The Fix 🔨

1. The Node version in the Rails Dockerfile was updated to 16 to match the version specified in package.json. 

2. The Dockerfile was updated to fix the bundler version, ensuring compatibility with the version specified in Gemfile.lock.





