### PR TITLE
Add "main" to package.json to fix eslint issues

### DIFF
--- a/vite-plugin-ruby/package.json
+++ b/vite-plugin-ruby/package.json
@@ -3,6 +3,7 @@
   "description": "Convention over configuration for using Vite in Ruby apps",
   "version": "3.2.1",
   "type": "module",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
### Description 📖

Using eslint, I'm getting an `import/no-unresolved: Unable to resolve path to module 'vite-plugin-ruby'` when it clearly exists. 

### Background 📜

Looking at [this ticket](https://github.com/browserify/resolve/issues/222) I believe that is happening because there is no `main` key in the package.json. Note that this error is not happening with the `vite-rails-plugin`, which does specify the `main` key.

### The Fix 🔨

This updates the package.json to include the `main` key.