### PR TITLE
Install node modules for engine when starting vite container for the Rails example

### DIFF
--- a/examples/rails/docker-vite.sh
+++ b/examples/rails/docker-vite.sh
@@ -4,5 +4,8 @@ set -e
 
 bin/docker_gems
 yarn install
+cd example_engine
+yarn install
+cd ..
 
 bin/vite dev

--- a/examples/rails/spec/features/admin/home_spec.rb
+++ b/examples/rails/spec/features/admin/home_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.feature 'Admin' do
+  before { visit(urls.administrator_path) }
+
+  scenario 'visit admin page' do
+    expect(page).to  have_content('Rails Engine')
+  end
+end


### PR DESCRIPTION
### Description 📖

This pull request fixes error visiting /admin path 'ViteRuby::MissingExecutableError in Administrator::Timer#index'

### Background 📜

This was happening because vite binary was not available for the engine (engine uses separate node_modules folder).

### The Fix 🔨

By running 'yarn install' within the engine's folder when starting vite container.

### Screenshots 📷
![image](https://github.com/ElMassimo/vite_ruby/assets/34840/b95faafc-69a2-4d1b-9bd7-f8c568522e91)
