### PR TITLE
Allow skipping dev dependencies on install

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -42,11 +42,11 @@ namespace :vite do
 
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
+    install_env_args = ENV['VITE_RUBY_SKIP_INSTALL_DEV_DEPENDENCIES'] == 'true' ? {} : { 'NODE_ENV' => 'development' }
     cmd = ViteRuby.commands.legacy_npm_version? ? 'npx ci --yes' : 'npx --yes ci'
-    result = system({ 'NODE_ENV' => 'development' }, cmd)
-
+    result = system(install_env_args, cmd)
     # Fallback to `yarn` if `npx` is not available.
-    system({ 'NODE_ENV' => 'development' }, 'yarn install --frozen-lockfile') if result.nil?
+    system(install_env_args, 'yarn install --frozen-lockfile') if result.nil?
   end
 
   desc "Provide information on ViteRuby's environment"


### PR DESCRIPTION
### Description 📖

Add an env flag `VITE_RUBY_SKIP_INSTALLING_DEV_DEPENDENCIES`, which lets users skip installing dev dependencies in the `install_dependencies` rake task

Not sure what's the best way to test this, so opening as a draft to ask for advice, and see if anyone else thinks this is useful. For my project `devDependencies` only includes non essential things like storybook and linters, hence why I'd like the option to skip installing them

### Background 📜

For projects where dev dependencies only include linters etc, this is a nice way of speeding up the build. Similar to how on legacy yarn you could run `yarn install --production`

### The Fix 🔨

Alter the task to optionally add `--omit=dev` to the `npx ci` build command.

### Screenshots 📷
