### PR TITLE
fix: Check only once per second when dev server is not running

### DIFF
--- a/test/dev_server_test.rb
+++ b/test/dev_server_test.rb
@@ -8,13 +8,18 @@ class DevServerTest < ViteRuby::Test
 
     refresh_config(mode: 'development')
     refute ViteRuby.instance.dev_server_running?
+
+    running_checked_at = ViteRuby.instance.instance_variable_get('@running_checked_at')
+    assert_in_delta(Time.now.to_f, running_checked_at.to_f, 0.01)
   end
 
   def test_running
     refresh_config(mode: 'development')
-    ViteRuby.instance.instance_variable_set('@running_at', Time.now)
+    ViteRuby.instance.instance_variable_set('@running', true)
+    ViteRuby.instance.instance_variable_set('@running_checked_at', Time.now)
     assert ViteRuby.instance.dev_server_running?
   ensure
-    ViteRuby.instance.remove_instance_variable('@running_at')
+    ViteRuby.instance.remove_instance_variable('@running')
+    ViteRuby.instance.remove_instance_variable('@running_checked_at')
   end
 end

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -85,13 +85,16 @@ class ViteRuby
   # NOTE: Checks only once every second since every lookup calls this method.
   def dev_server_running?
     return false unless run_proxy?
-    return true if @running_at && Time.now - @running_at < 1
+    return @running if defined?(@running) && Time.now - @running_checked_at < 1
 
-    Socket.tcp(config.host, config.port, connect_timeout: config.dev_server_connect_timeout).close
-    @running_at = Time.now
-    true
-  rescue StandardError
-    @running_at = false
+    begin
+      Socket.tcp(config.host, config.port, connect_timeout: config.dev_server_connect_timeout).close
+      @running = true
+    rescue StandardError
+      @running = false
+    ensure
+      @running_checked_at = Time.now
+    end
   end
 
   # Public: Additional environment variables to pass to Vite.


### PR DESCRIPTION
### Description 📖

This pull request speeds up performance considerably in local test environments by reducing the frequency of the dev server check when the dev server is not running.

### Background 📜

The comment for the `dev_server_running?` method says:

> Checks only once every second

However, in reality that is only true with the dev server is running.

When the dev server is _not_ running, no timestamp is recorded. That means that the dev server check is performed with every manifest lookup.

### The Fix 🔨

Store a timestamp in `@running_checked_at` regardless of whether the dev server check succeeds or fails. This ensures that the dev server check is done at most once per second, even if the dev server is not running.

### Screenshots 📷

In a Rails app with a large number of images and stylesheets (i.e. many manifest lookups per page), this patch resulted in an 18x performance improvement when running system specs.

Before:

```
Finished in 4 minutes 15.7 seconds (files took 2.93 seconds to load)
22 examples, 0 failures
```

After:

```
Finished in 14.2 seconds (files took 2.84 seconds to load)
22 examples, 0 failures
```