### PR TITLE
Update `vite_preload_tag` to emit one early hint per entrypoint

### DIFF
--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -88,10 +88,15 @@ private
 
   # Internal: Renders a modulepreload link tag.
   def vite_preload_tag(*sources, crossorigin:, **options)
-    sources.map { |source|
-      href = path_to_asset(source)
-      try(:request).try(:send_early_hints, 'Link' => %(<#{ href }>; rel=modulepreload; as=script; crossorigin=#{ crossorigin }))
+    asset_paths = sources.map { | source | path_to_asset(source) }
+    try(:request).try(
+      :send_early_hints,
+      'Link' => asset_paths.map do |href|
+        %(<#{ href }>; rel=modulepreload; as=script; crossorigin=#{ crossorigin })
+      end.join(", "),
+    )
+    asset_paths.map do |href|
       tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **options)
-    }.join("\n").html_safe
+    end.join("\n").html_safe
   end
 end

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -91,12 +91,12 @@ private
     asset_paths = sources.map { |source| path_to_asset(source) }
     try(:request).try(
       :send_early_hints,
-      'Link' => asset_paths.map do |href|
+      'Link' => asset_paths.map { |href|
         %(<#{ href }>; rel=modulepreload; as=script; crossorigin=#{ crossorigin })
-      end.join("\n"),
+      }.join("\n"),
     )
-    asset_paths.map do |href|
+    asset_paths.map { |href|
       tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **options)
-    end.join('\n').html_safe
+    }.join("\n").html_safe
   end
 end

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -88,7 +88,7 @@ private
 
   # Internal: Renders a modulepreload link tag.
   def vite_preload_tag(*sources, crossorigin:, **options)
-    asset_paths = sources.map { | source | path_to_asset(source) }
+    asset_paths = sources.map { |source| path_to_asset(source) }
     try(:request).try(
       :send_early_hints,
       'Link' => asset_paths.map do |href|
@@ -97,6 +97,6 @@ private
     )
     asset_paths.map do |href|
       tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **options)
-    end.join("\n").html_safe
+    end.join('\n').html_safe
   end
 end

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -93,7 +93,7 @@ private
       :send_early_hints,
       'Link' => asset_paths.map do |href|
         %(<#{ href }>; rel=modulepreload; as=script; crossorigin=#{ crossorigin })
-      end.join(", "),
+      end.join("\n"),
     )
     asset_paths.map do |href|
       tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **options)


### PR DESCRIPTION
### Description 📖

Update `vite_preload_tag` to emit one early hint per entrypoint
Avoids error like "too many 1xx informational responses"

### Background 📜

I am trying this gem with caddy as reverse proxy
And visiting the deployed website returns 502, log shows "too many 1xx informational responses"
I found this issue is reported https://github.com/caddyserver/caddy/issues/5616
Which is caused by having too many 103 responses sent

### The Fix 🔨

Update `vite_preload_tag` to emit one early hint per entrypoint (actually all sources input, but it's mainly used by `vite_javascript_tag`)

### Screenshots 📷
N/A
