### PR TITLE
feat: allow skipping dependencies install.

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -42,6 +42,8 @@ namespace :vite do
 
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
+    return if ENV['VITE_RUBY_SKIP_INSTALL_DEPENDENCIES'] == 'true'
+
     install_env_args = ENV['VITE_RUBY_SKIP_INSTALL_DEV_DEPENDENCIES'] == 'true' ? {} : { 'NODE_ENV' => 'development' }
     cmd = ViteRuby.commands.legacy_npm_version? ? 'npx ci --yes' : 'npx --yes ci'
     result = system(install_env_args, cmd)


### PR DESCRIPTION
### Description 📖

Add an env flag VITE_RUBY_SKIP_INSTALLING_DEPENDENCIES, which lets users skip installing all node dependencies in the install_dependencies rake task. This is similar to the existing VITE_RUBY_SKIP_INSTALLING_DEV_DEPENDENCIES flag.

### Background 📜

The reason our team would like this is the following: We are trying to optimize our CI/CD running time and are working at parallelizing as many tasks as we can. We already installed our dependencies in another step and cached them. When we get to the "assets compilation" step, we would like to use those cached dependencies. Unfortunately, in its current state, the vite dependency installation step not only runs the dependency install again, but it also blows away our cache by using `npx ci` (which from our understanding uses `npm ci` in the background).

One workaround we found was using the `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION` flag, but that skips the assets' precompilation, which we do want. By using that flag, we can then call `bin/rake vite:build_all`. This path is also acceptable, but I thought others might benefit from this flag instead in order to make their own CI setups easier. I've opened this PR both as a discussion forum and as a potential solution in case it's accepted.

### The Fix 🔨

Added a new flag which skips the `install_dependencies` task.

### Screenshots 📷
