### PR TITLE
Respect host and protocol options in vite_preload_tag

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -105,6 +105,14 @@ class HelperTest < HelperTestCase
     }
   end
 
+  def test_vite_preload_tag
+    assert_includes vite_typescript_tag('main', host: 'example.com', protocol: 'https'), [
+      %(<link rel="modulepreload" href="https://example.com/vite-production/assets/log.818edfb8.js" as="script" crossorigin="anonymous">),
+      %(<link rel="modulepreload" href="https://example.com/vite-production/assets/vue.3002ada6.js" as="script" crossorigin="anonymous">),
+      %(<link rel="modulepreload" href="https://example.com/vite-production/assets/vendor.0f7c0ec3.js" as="script" crossorigin="anonymous">),
+    ].join("\n")
+  end
+
   def test_vite_javascript_tag
     assert_similar [
       %(<script src="/vite-production/assets/main.9dcad042.js" crossorigin="anonymous" type="module"></script>),

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -101,7 +101,8 @@ private
 
   # Internal: Renders a modulepreload link tag.
   def vite_preload_tag(*sources, crossorigin:, **options)
-    asset_paths = sources.map { |source| path_to_asset(source) }
+    url_options, tag_options = options.partition { |key, _| %i[host protocol].include?(key) }.map(&:to_h)
+    asset_paths = sources.map { |source| path_to_asset(source, url_options) }
     try(:request).try(
       :send_early_hints,
       'Link' => asset_paths.map { |href|
@@ -109,7 +110,7 @@ private
       }.join("\n"),
     )
     asset_paths.map { |href|
-      tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **options)
+      tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **tag_options)
     }.join("\n").html_safe
   end
 end

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -101,8 +101,8 @@ private
 
   # Internal: Renders a modulepreload link tag.
   def vite_preload_tag(*sources, crossorigin:, **options)
-    url_options, tag_options = options.partition { |key, _| %i[host protocol].include?(key) }.map(&:to_h)
-    asset_paths = sources.map { |source| path_to_asset(source, url_options) }
+    url_options = options.extract!(:host, :protocol)
+    asset_paths = sources.map { |source| path_to_asset(source, **url_options) }
     try(:request).try(
       :send_early_hints,
       'Link' => asset_paths.map { |href|
@@ -110,7 +110,7 @@ private
       }.join("\n"),
     )
     asset_paths.map { |href|
-      tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **tag_options)
+      tag.link(rel: 'modulepreload', href: href, as: 'script', crossorigin: crossorigin, **options)
     }.join("\n").html_safe
   end
 end


### PR DESCRIPTION
### Description 📖

When specifying the host and protocol options for a `vite_javascript_tag`, we want the preload tags to also respect those options.

### Background 📜

This was causing an issue where the preload tags would not use the CDN specified for the `vite_javascript_tag`.
