### PR TITLE
Automatically eager load ViteRuby in Rails context

### DIFF
--- a/vite_rails/lib/vite_rails/engine.rb
+++ b/vite_rails/lib/vite_rails/engine.rb
@@ -23,7 +23,9 @@ class ViteRails::Engine < Rails::Engine
     end
   end
 
-  initializer 'vite_rails.bootstrap' do
+  initializer 'vite_rails.bootstrap' do |app|
+    app.config.eager_load_namespaces << ViteRuby
+
     if defined?(Rails::Server) || defined?(Rails::Console)
       ViteRuby.bootstrap
       if defined?(Spring)

--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -44,6 +44,8 @@ class ViteRuby
       instance.manifest.refresh
     end
 
+    alias eager_load! bootstrap
+
     # Internal: Loads all available rake tasks.
     def install_tasks
       load File.expand_path('tasks/vite.rake', __dir__)


### PR DESCRIPTION
### Description 📖

Ensures the ViteRuby manifest is eager loaded, following the Rails pattern (similarly to https://github.com/tzinfo/tzinfo/commit/c4f177c4808c11aa28f87fb3b452f832342c970c).

In dev, when running a rails console or `bin/rails server`, the manifest is already loaded (because of the `Rails::Server` and `Rails::Console` definition checks). But in some environments (e.g. when booting the server through Puma), those constants aren't defined, but we still want to eagerload the manifest.

The PR is still in draft as I dig into why the constants aren't always defined.
