### PR TITLE
docs: update readme to reflect vite's deprecation of globEager

### DIFF
--- a/docs/src/guide/plugins.md
+++ b/docs/src/guide/plugins.md
@@ -98,7 +98,7 @@ const path = videoClips.download.path(video) // "/video_clips/5/download"
 Use <kbd>[stimulus-vite-helpers]</kbd> to easily register all [Stimulus] controllers using [`globEager`][glob import].
 
 ```ts
-const controllers = import.meta.globEager('./**/*_controller.js')
+const controllers = import.meta.glob('./**/*_controller.js', { eager: true })
 registerControllers(application, controllers)
 ```
 

--- a/docs/src/guide/plugins.md
+++ b/docs/src/guide/plugins.md
@@ -95,7 +95,7 @@ const path = videoClips.download.path(video) // "/video_clips/5/download"
 
 ## [Stimulus Helpers](https://github.com/ElMassimo/stimulus-vite-helpers)
 
-Use <kbd>[stimulus-vite-helpers]</kbd> to easily register all [Stimulus] controllers using [`globEager`][glob import].
+Use <kbd>[stimulus-vite-helpers]</kbd> to easily register all [Stimulus] controllers using [`import.meta.glob`][glob import].
 
 ```ts
 const controllers = import.meta.glob('./**/*_controller.js', { eager: true })


### PR DESCRIPTION
From https://github.com/ElMassimo/stimulus-vite-helpers/pull/12#issue-2048150674,

> The `globEager` function was deprecated as of Vite 3.0 and has been removed in Vite 5.0. This updates the README to use the suggested `glob` function with an eager argument instead.
> 
> https://vitejs.dev/guide/migration#removed-deprecated-apis [vitejs/vite#14118](https://github.com/vitejs/vite/pull/14118)

I noticed that the plugins page was missing that, I was in the process of upgrading vite-ruby and had some hard time because the docs was not being reflected.

Hope this helps others out.

Thanks for this amazing project!