### PR TITLE
Add `vite.config.mjs` to watched paths

### DIFF
--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -195,6 +195,7 @@ private
     postcss.config.js
     tailwind.config.js
     vite.config.js
+    vite.config.mjs
     vite.config.ts
     windi.config.ts
     yarn.lock


### PR DESCRIPTION
### Description 📖

This ensures building isn't skipped when `.mjs` extension is used for the Vite config file.

### Background 📜

Vite 5 deprecated CJS, so unless `"type": "module"` is specified in `package.json` (which requires using `.cjs` extension things like PostCSS config), the only way to avoid the deprecation warning is to rename the config file to `vite.config.mjs`.

https://vitejs.dev/guide/migration.html#deprecate-cjs-node-api

### The Fix 🔨

I added `vite.config.mjs` to default watched paths.
