### PR TITLE
feat: allow skipping dependency install in assets:precompile

### DIFF
--- a/docs/src/guide/deployment.md
+++ b/docs/src/guide/deployment.md
@@ -101,6 +101,9 @@ along the `assets:precompile` rake task.
 You can disable the extension of the `assets:precompile` rake task by setting
 the `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION` environment variable to `true`.
 
+By default, dependencies will be automatically installed as part of the `assets:precompile` extension.
+Set `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL` to `true` to skip dependency installation.
+
 ## Compressing Assets 📦
 
 Most CDN and edge service providers will automatically serve compressed assets,

--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -59,12 +59,18 @@ unless ENV['VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION'] == 'true'
   if Rake::Task.task_defined?('assets:precompile')
     Rake::Task['assets:precompile'].enhance do |task|
       prefix = task.name.split(/#|assets:precompile/).first
-      Rake::Task["#{ prefix }vite:install_dependencies"].invoke
+      unless ENV['VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL'] == 'true'
+        Rake::Task["#{ prefix }vite:install_dependencies"].invoke
+      end
       Rake::Task["#{ prefix }vite:build_all"].invoke
     end
   else
     desc 'Bundle Vite assets'
-    Rake::Task.define_task('assets:precompile' => ['vite:install_dependencies', 'vite:build_all'])
+    if ENV['VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL'] == 'true'
+      Rake::Task.define_task('assets:precompile' => 'vite:build_all')
+    else
+      Rake::Task.define_task('assets:precompile' => ['vite:install_dependencies', 'vite:build_all'])
+    end
   end
 
   unless Rake::Task.task_defined?('assets:clean')


### PR DESCRIPTION
### Description 📖

We want to use the `assets:precompile` extension but we don't want it to install dependencies. This allows setting `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL=true` to skip installation while keeping the rest of the task extensions.

### Background 📜

This was happening because dependencies are always installed (`yarn install` / `npx ci`) as part of the `assets:precompile` extension.

### The Fix 🔨

Add conditional controlled by `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL` to allow for skipping the installation task.
