### PR TITLE
Fix for "uninitialized constant ViteRuby::Manifest::OpenStruct" Error

### DIFF
--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 # Public: Registry for accessing resources managed by Vite, using a generated
 # manifest file which maps entrypoint names to file paths.
 #


### PR DESCRIPTION
### Description 📖

This pull request specifically targets an issue occurring only when encountering `ViteRuby::MissingEntrypointError`. 
The problem stems from the absence of `require 'ostruct'` in these error scenarios. 
This fix ensures that `require 'ostruct'` is included in the appropriate context, resolving the issue and preventing errors during `ViteRuby::MissingEntrypointError` occurrences.
