### PR TITLE
fix: use correct dirname for manifest

### DIFF
--- a/vite-plugin-ruby/src/manifest.ts
+++ b/vite-plugin-ruby/src/manifest.ts
@@ -47,7 +47,7 @@ export function assetsManifestPlugin (): Plugin {
     async generateBundle (_options, bundle) {
       if (!config.build.manifest) return
 
-      const manifestDir = typeof config.build.manifest === 'string' ? path.basename(config.build.manifest) : '.vite'
+      const manifestDir = typeof config.build.manifest === 'string' ? path.dirname(config.build.manifest) : '.vite'
       const fileName = `${manifestDir}/manifest-assets.json`
 
       const manifest: AssetsManifest = new Map()


### PR DESCRIPTION
### Description 📖

Uses `path.dirname` instead of `path.basename` so we correctly determine the `manifestDir` in the assets-manifest plugin.

### Background 📜

This was happening because the package was using `path.basename`, which gives the file name and not the directory name.

### The Fix 🔨

Change `path.basename` to `path.dirname`

### Screenshots 📷

N/A
