### PR TITLE
Add env var entry to docs/config

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -315,6 +315,16 @@ You can customize this behavior using the following options.
 
   Otherwise, this setting allows to skip that check. Use it responsibly.
 
+### skipInstallDevDependencies
+
+- **Version Added:** ``
+- **Default:** `false`
+- **Env Var:** `VITE_RUBY_SKIP_INSTALL_DEV_DEPENDENCIES`
+
+ Skip `npx ci` from being ran, which happens when for example, `bundle exec assets:precompile` is ran.
+ When this is enabled, packages specified in the lock file are installed through the package manager available.
+
+
 ### skipProxy (experimental)
 
 - **Version Added:** `3.2.12`


### PR DESCRIPTION
Please add version added, and edit my copy as you wish, I am just trying to facilitate the entry of this config option.

### Background 📜

This was happening because there is no mention to this in the docs

### The Fix 🔨

By adding an entry to the docs
