### PR TITLE
Update `actions/checkout` to v4 (node 16->20)

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container: algolia/docsearch-scraper
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: 'sudo apt-get install -y jq'
       - run: 'echo "CONFIG=$(cat docs/.algolia/config.json | jq -r tostring)" >> $GITHUB_ENV'
       - run: "cd /root && pipenv install"

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.6.5
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,7 +14,7 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Gets rid of deprecation noise in some of the CI runs.