### PR TITLE
Use `SECRET_KEY_BASE_DUMMY` feature as placeholder during build

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,7 @@ jobs:
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}
+      SECRET_KEY_BASE_DUMMY: 1
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I think this will fix the very bottom (Rails edge run) here - https://github.com/ElMassimo/vite_ruby/actions/runs/9422889978/job/25960116922

Rails after 7.1 has switched to expect the secret_key_base to come from credentials, so the secret_key_base config setting from the dummy apps doesn't get picked up, hence that error. This env var should trigger a dummy value to be used (see note in bottom of https://guides.rubyonrails.org/asset_pipeline.html#local-precompilation)