### PR TITLE
Drop EOL ruby from CI config

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: [
-          "3.0",
           "3.1",
           "3.2",
           "3.3",


### PR DESCRIPTION
I see the gemspec still supports some quite old ruby/rails versions ... but seems reasonable to just run non-EOL'd on CI?