### PR TITLE
Rename `test_app_path` -> `path_to_test_app` (avoids minitest warning)

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -15,7 +15,7 @@ class ConfigTest < ViteRuby::Test
     assert_equal Pathname.new(expand_path("test_app/#{ expected }")), actual
   end
 
-  def resolve_config(mode: 'production', root: test_app_path, **attrs)
+  def resolve_config(mode: 'production', root: path_to_test_app, **attrs)
     ViteRuby::Config.resolve_config(mode: mode, root: root, **attrs)
   end
 

--- a/test/engine_rake_tasks_test.rb
+++ b/test/engine_rake_tasks_test.rb
@@ -180,7 +180,7 @@ private
     [app_frontend_dir, app_public_dir, app_ssr_dir, tmp_dir].each do |dir|
       dir.rmtree if dir.exist?
     end
-    root_dir.join('app/views/layouts/application.html.erb').write(Pathname.new(test_app_path).join('app/views/layouts/application.html.erb').read)
+    root_dir.join('app/views/layouts/application.html.erb').write(Pathname.new(path_to_test_app).join('app/views/layouts/application.html.erb').read)
     gitignore_path.write('')
     @command_results = []
   end

--- a/test/rake_tasks_test.rb
+++ b/test/rake_tasks_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class RakeTasksTest < ViteRuby::Test
   def test_rake_tasks
     assert ViteRuby.install_tasks
-    output = Dir.chdir(test_app_path) { `rake -T` }
+    output = Dir.chdir(path_to_test_app) { `rake -T` }
     assert_includes output, 'vite:build'
     assert_includes output, 'vite:build_ssr'
     assert_includes output, 'vite:clean'
@@ -15,7 +15,7 @@ class RakeTasksTest < ViteRuby::Test
   end
 
   def test_rake_task_vite_check_binstubs
-    output = Dir.chdir(test_app_path) { `rake vite:verify_install 2>&1` }
+    output = Dir.chdir(path_to_test_app) { `rake vite:verify_install 2>&1` }
     refute_includes output, 'vite binstub not found.'
   end
 
@@ -23,7 +23,7 @@ class RakeTasksTest < ViteRuby::Test
     assert_includes test_app_dev_dependencies, 'right-pad'
 
     ViteRuby.commands.send(:with_node_env, 'test') do
-      Dir.chdir(test_app_path) do
+      Dir.chdir(path_to_test_app) do
         `bundle exec rake vite:install_dependencies`
       end
     end
@@ -34,7 +34,7 @@ class RakeTasksTest < ViteRuby::Test
 
   def test_rake_vite_install_dependencies_in_production_environment
     ViteRuby.commands.send(:with_node_env, 'production') do
-      Dir.chdir(test_app_path) do
+      Dir.chdir(path_to_test_app) do
         `bundle exec rake vite:install_dependencies`
       end
     end
@@ -45,17 +45,17 @@ class RakeTasksTest < ViteRuby::Test
 
 private
 
-  def test_app_path
+  def path_to_test_app
     File.expand_path('test_app', __dir__)
   end
 
   def test_app_dev_dependencies
-    package_json = File.expand_path('package.json', test_app_path)
+    package_json = File.expand_path('package.json', path_to_test_app)
     JSON.parse(File.read(package_json))['devDependencies']
   end
 
   def installed_node_module_names
-    node_modules_path = File.expand_path('node_modules', test_app_path)
+    node_modules_path = File.expand_path('node_modules', path_to_test_app)
     Dir.chdir(node_modules_path) { Dir.glob('*') }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,7 @@ module ViteRubyTestHelpers
     refresh_config
   end
 
-  def test_app_path
+  def path_to_test_app
     File.expand_path('test_app', __dir__)
   end
 
@@ -70,7 +70,7 @@ private
   end
 
   def assert_run_command(*argv, flags: [])
-    Dir.chdir(test_app_path) {
+    Dir.chdir(path_to_test_app) {
       begin
         mock = Minitest::Mock.new
         mock.expect(:call, nil, [ViteRuby.config.to_env, %r{node_modules/.bin/vite}, *argv, *flags])


### PR DESCRIPTION
In rails edge there's a helper in place that looks for tests without assertions and warns - https://github.com/rails/rails/blob/main/activesupport/test/testing/test_without_assertions_test.rb#L20

The rails edge CI runs have such a warning, example: https://github.com/ElMassimo/vite_ruby/actions/runs/9424262054/job/25964175625#step:6:12

This change just renames the method to not start with `test_` to silence that warning.