### PR TITLE
Use Rails `load_defaults` for relevant gemfile in test runs

### DIFF
--- a/test/mounted_app/test/dummy/config/application.rb
+++ b/test/mounted_app/test/dummy/config/application.rb
@@ -12,7 +12,8 @@ end
 
 module TestDummyApp
   class Application < Rails::Application
-    config.secret_key_base = 'abcdef'
+    config.load_defaults Rails::VERSION::STRING.to_f
+    config.secret_key_base = SecureRandom.hex
     config.eager_load = true
   end
 end

--- a/test/test_app/config/application.rb
+++ b/test/test_app/config/application.rb
@@ -18,8 +18,14 @@ require 'vite_plugin_legacy'
 
 module TestApp
   class Application < ::Rails::Application
-    config.secret_key_base = 'abcdef'
+    config.load_defaults Rails::VERSION::STRING.to_f
+    config.secret_key_base = SecureRandom.hex
     config.eager_load = true
     config.active_support.test_order = :sorted
+
+    if Rails.gem_version >= Gem::Version.new('7.0.0')
+      # Option added in Rails 7.0, defaults to false. Some helper_test tests assume true.
+      config.action_view.apply_stylesheet_media_default = true
+    end
   end
 end


### PR DESCRIPTION
All non-EOL'd Rails version at this point support a `load_defaults` method which can be used to tell Rails which version defaults to start with.

Some of the rails-version-gemfile test runs currently have deprecations about options that are either changing or going away or whatever, but these can generally be silenced by telling a given version to use it's own defaults, which is what this PR does.

Example of warning: https://github.com/ElMassimo/vite_ruby/actions/runs/9424262054/job/25964175006#step:6:9

The one oddity here (explained with inline comment in the diff) is the behavior of `media: screen`. In versions prior to 7.0, the `media` attribute in stylesheet tags would default to `screen`. That was changed in 7.0 to not be there by default, a behvaior which has a config option to enable/disable - https://github.com/rails/rails/commit/1280620767c6ce45576b893a8073d44590f4511c

I've chosen here to do the smallest diff approach - which is to just enable the option, which keeps the `link` method helper in helper_test working as-is (has a default media attribute). Another approach would be to leave the default off, and then modify that helper to default to no media, and only add one if passed in.