### PR TITLE
Add missing `.ts` extension in `application.js` example

### DIFF
--- a/vite_rails/templates/entrypoints/application.js
+++ b/vite_rails/templates/entrypoints/application.js
@@ -6,7 +6,7 @@
 console.log('Vite ⚡️ Rails')
 
 // If using a TypeScript entrypoint file:
-//     <%= vite_typescript_tag 'application' %>
+//     <%= vite_typescript_tag 'application.ts' %>
 //
 // If you want to use .jsx or .tsx, add the extension:
 //     <%= vite_javascript_tag 'application.jsx' %>

--- a/vite_rails_legacy/templates/entrypoints/application.js
+++ b/vite_rails_legacy/templates/entrypoints/application.js
@@ -6,7 +6,7 @@
 console.log('Vite ⚡️ Rails')
 
 // If using a TypeScript entrypoint file:
-//     <%= vite_typescript_tag 'application' %>
+//     <%= vite_typescript_tag 'application.ts' %>
 //
 // If you want to use .jsx or .tsx, add the extension:
 //     <%= vite_javascript_tag 'application.jsx' %>


### PR DESCRIPTION
### Description 📖

In the latest Vite, the default falls to `.js`, therefore `.ts` needs to be explicitly specified.

### The Fix 🔨

By updating the example to include the `.ts` file extension
