### PR TITLE
docs: More robust solution to Safari dev cache bug

### DIFF
--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -158,11 +158,23 @@ This is probably the case if you are seeing errors such as `#<Errno::EMFILE: Too
 
 Follow [this article][ulimit] for information on how to increase the limit of file descriptors in your OS.
 
-### Safari does not reflect CSS changes in development
+### Safari does not reflect CSS and JS changes in development
 
-Safari [ignores](https://apple.stackexchange.com/questions/439451/safari-is-caching-hard-i-have-to-empty-for-each-change-in-my-css) the `Cache-Control: no-cache` header for CSS stylesheets, which is inconvenient in development as HMR for CSS does not work as expected, requiring the cache to be cleared manually in order to see changes.
+Safari [ignores](https://bugs.webkit.org/show_bug.cgi?id=193533) the `Cache-Control: no-cache` header for preloaded CSS and JS files, which is inconvenient in development as HMR does not work as expected, requiring the cache to be cleared manually in order to see changes.
 
-A workaround is to import the CSS from a [`vite_javascript_tag` entrypoint][smart output] instead of using `vite_stylesheet_tag`. When the CSS is requested in this way it becomes a JS request in development, avoiding the bug in Safari.
+By default, Rails javascript and stylesheet tag helpers cause a `Link: ... rel=preload` header to be emitted, which triggers the Safari bug. As a workaround, you can disable the preload behavior in development as follows:
+
+```ruby
+# config/environments/development.rb
+
+Rails.application.configure do
+  # Disable `Link: ... rel=preload` header to workaround Safari caching bug
+  # https://bugs.webkit.org/show_bug.cgi?id=193533
+  config.action_view.preload_links_header = false
+end
+```
+
+With preloading disabled, Safari will properly refresh changed files and HMR will work.
 
 ## Fixed Issues
 


### PR DESCRIPTION
### Description 📖

Safari had an annoying bug where it will ignore changes to CSS files, breaking the developer's hot-reload experience. The Vite Ruby troubleshooting guide [recommends](https://github.com/ElMassimo/vite_ruby/blob/4433471406e7e4957e13acee5151829b36a8eb60/docs/src/guide/troubleshooting.md#L161) moving CSS into the JS entrypoint as a workaround.

However, in Safari 17.5, the problem is now even worse: the bug now affects JS files as well. That means the previously documented workaround is no longer a solution for the entire scope of Safari HMR issues.

### Background 📜

Ultimately, the problem is a known bug in Safari where it aggressively caches JS and CSS files that are marked `rel=preload`.

> If a request is preloaded, Safari will always retrieve it from the cache, regardless of the cache headers for that request.

https://bugs.webkit.org/show_bug.cgi?id=193533

### The Fix 🔨

Update the Vite Ruby troubleshooting guide with a more robust workaround: disable the `rel=preload` Link header in development. This completely solves the issue for me.

FWIW, I'm running:

macOS 14.5 (23F79)
Safari 17.5 (19618.2.12.11.6)