### PR TITLE
fix: Retain bundled current files (close #438)

### DIFF
--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -41,6 +41,8 @@ class CommandsTest < ViteRuby::Test
 
       js_file = config.build_output_dir.join('assets/application.js')
       js_file.write('export {}')
+      css_module = config.build_output_dir.join('assets/styles.css')
+      css_module.write('.foo {}')
 
       # Simulate using vite-plugin-rails & rollup-plugin-gzip to produce
       # source maps, gzip & brotli compressed versions of the file.
@@ -50,6 +52,10 @@ class CommandsTest < ViteRuby::Test
       gzip_file.write('export {}')
       brotli_file = config.build_output_dir.join('assets/application.js.br')
       brotli_file.write('export {}')
+      css_gzip_file = config.build_output_dir.join('assets/styles.css.gz')
+      css_gzip_file.write('.foo {}')
+      css_brotli_file = config.build_output_dir.join('assets/styles.css.br')
+      css_brotli_file.write('.foo {}')
 
       # Should not clean, the manifest does not exist.
       refute clean
@@ -64,15 +70,28 @@ class CommandsTest < ViteRuby::Test
       assert_path_exists source_map_file
       assert_path_exists gzip_file
       assert_path_exists brotli_file
+      assert_path_exists css_module
+      assert_path_exists css_gzip_file
+      assert_path_exists css_brotli_file
 
       # Should not clean if directly referenced.
-      manifest.write('{ "application.js": { "file": "assets/application.js" } }')
+      manifest.write('{
+        "application.js": {
+          "css": [
+            "assets/styles.css"
+          ],
+          "file": "assets/application.js"
+        }
+      }')
       assert clean(keep_up_to: 0, age_in_seconds: 0)
       assert_path_exists manifest
       assert_path_exists js_file
       assert_path_exists source_map_file
       assert_path_exists gzip_file
       assert_path_exists brotli_file
+      assert_path_exists css_module
+      assert_path_exists css_gzip_file
+      assert_path_exists css_brotli_file
 
       # Should clean if we remove age restrictions.
       manifest.write('{}')
@@ -83,6 +102,9 @@ class CommandsTest < ViteRuby::Test
       refute_path_exists source_map_file
       refute_path_exists gzip_file
       refute_path_exists brotli_file
+      refute_path_exists css_module
+      refute_path_exists css_gzip_file
+      refute_path_exists css_brotli_file
     }
   end
 

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -81,6 +81,9 @@ class CommandsTest < ViteRuby::Test
             "assets/styles.css"
           ],
           "file": "assets/application.js"
+        },
+        "noassetsorcss.js": {
+          "file": "assets/noassetsorcss.js"
         }
       }')
       assert clean(keep_up_to: 0, age_in_seconds: 0)

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -68,6 +68,7 @@ class CommandsTest < ViteRuby::Test
       # Should not clean if directly referenced.
       manifest.write('{ "application.js": { "file": "assets/application.js" } }')
       assert clean(keep_up_to: 0, age_in_seconds: 0)
+      assert_path_exists manifest
       assert_path_exists js_file
       assert_path_exists source_map_file
       assert_path_exists gzip_file
@@ -77,6 +78,7 @@ class CommandsTest < ViteRuby::Test
       manifest.write('{}')
       assert clean(keep_up_to: 0, age_in_seconds: 0)
       assert_path_exists config.build_output_dir
+      assert_path_exists manifest
       refute_path_exists js_file
       refute_path_exists source_map_file
       refute_path_exists gzip_file

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -37,30 +37,50 @@ class CommandsTest < ViteRuby::Test
 
   def test_clean
     with_rails_env('test') { |config|
-      manifest = config.build_output_dir.join('.vite/manifest.json')
+      ensure_output_dirs(config)
+
       js_file = config.build_output_dir.join('assets/application.js')
+      js_file.write('export {}')
+
+      # Simulate using vite-plugin-rails & rollup-plugin-gzip to produce
+      # source maps, gzip & brotli compressed versions of the file.
+      source_map_file = config.build_output_dir.join('assets/application.js.map')
+      source_map_file.write('export {}')
+      gzip_file = config.build_output_dir.join('assets/application.js.gz')
+      gzip_file.write('export {}')
+      brotli_file = config.build_output_dir.join('assets/application.js.br')
+      brotli_file.write('export {}')
 
       # Should not clean, the manifest does not exist.
-      ensure_output_dirs(config)
       refute clean
 
-      # Should not clean, the file is recent.
+      manifest = config.build_output_dir.join('.vite/manifest.json')
       manifest.write('{}')
-      js_file.write('export {}')
+
+      # Should not clean, the file is recent.
       assert clean_from_task(OpenStruct.new)
       assert_path_exists manifest
       assert_path_exists js_file
+      assert_path_exists source_map_file
+      assert_path_exists gzip_file
+      assert_path_exists brotli_file
 
       # Should not clean if directly referenced.
       manifest.write('{ "application.js": { "file": "assets/application.js" } }')
       assert clean(keep_up_to: 0, age_in_seconds: 0)
       assert_path_exists js_file
+      assert_path_exists source_map_file
+      assert_path_exists gzip_file
+      assert_path_exists brotli_file
 
       # Should clean if we remove age restrictions.
       manifest.write('{}')
       assert clean(keep_up_to: 0, age_in_seconds: 0)
       assert_path_exists config.build_output_dir
       refute_path_exists js_file
+      refute_path_exists source_map_file
+      refute_path_exists gzip_file
+      refute_path_exists brotli_file
     }
   end
 

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -43,6 +43,8 @@ class CommandsTest < ViteRuby::Test
       js_file.write('export {}')
       css_module = config.build_output_dir.join('assets/styles.css')
       css_module.write('.foo {}')
+      image = config.build_output_dir.join('assets/image.svg')
+      image.write('<svg/>')
 
       # Simulate using vite-plugin-rails & rollup-plugin-gzip to produce
       # source maps, gzip & brotli compressed versions of the file.
@@ -73,10 +75,14 @@ class CommandsTest < ViteRuby::Test
       assert_path_exists css_module
       assert_path_exists css_gzip_file
       assert_path_exists css_brotli_file
+      assert_path_exists image
 
       # Should not clean if directly referenced.
       manifest.write('{
         "application.js": {
+          "assets": [
+            "assets/image.svg"
+          ],
           "css": [
             "assets/styles.css"
           ],
@@ -95,6 +101,7 @@ class CommandsTest < ViteRuby::Test
       assert_path_exists css_module
       assert_path_exists css_gzip_file
       assert_path_exists css_brotli_file
+      assert_path_exists image
 
       # Should clean if we remove age restrictions.
       manifest.write('{}')
@@ -108,6 +115,7 @@ class CommandsTest < ViteRuby::Test
       refute_path_exists css_module
       refute_path_exists css_gzip_file
       refute_path_exists css_brotli_file
+      refute_path_exists image
     }
   end
 

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -142,8 +142,8 @@ private
   end
 
   def versions
-    all_files = Dir.glob("#{ config.build_output_dir }/**/*")
-    entries = all_files - config.manifest_paths - files_to_retain
+    all_files = Dir.glob("#{ config.build_output_dir }/**/*", File::FNM_DOTMATCH)
+    entries = all_files - config.manifest_paths.map(&:to_s) - files_to_retain
     entries.reject { |file| File.directory?(file) }
       .group_by { |file| File.mtime(file).utc.to_i }
       .sort.reverse

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -151,7 +151,9 @@ private
 
   def files_referenced_in_manifests
     config.manifest_paths.flat_map { |path|
-      JSON.parse(path.read).flat_map { |_, entry| [entry['file']] + entry['css'] }
+      JSON.parse(path.read).flat_map do |_, entry|
+        [entry['file']] + entry.fetch('css', [])
+      end
     }.compact.uniq.map { |path| config.build_output_dir.join(path).to_s }
   end
 

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -152,7 +152,7 @@ private
   def files_referenced_in_manifests
     config.manifest_paths.flat_map { |path|
       JSON.parse(path.read).flat_map do |_, entry|
-        [entry['file']] + entry.fetch('css', [])
+        [entry['file']] + entry.fetch('css', []) + entry.fetch('assets', [])
       end
     }.compact.uniq.map { |path| config.build_output_dir.join(path).to_s }
   end

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -143,7 +143,7 @@ private
 
   def versions
     all_files = Dir.glob("#{ config.build_output_dir }/**/*")
-    entries = all_files - config.manifest_paths - files_referenced_in_manifests
+    entries = all_files - config.manifest_paths - files_to_retain
     entries.reject { |file| File.directory?(file) }
       .group_by { |file| File.mtime(file).utc.to_i }
       .sort.reverse
@@ -153,6 +153,10 @@ private
     config.manifest_paths.flat_map { |path|
       JSON.parse(path.read).map { |_, entry| entry['file'] }
     }.compact.uniq.map { |path| config.build_output_dir.join(path).to_s }
+  end
+
+  def files_to_retain
+    Dir.glob(files_referenced_in_manifests.map { |path| "#{ path }*" }).flatten
   end
 
   def with_node_env(env)

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -151,7 +151,7 @@ private
 
   def files_referenced_in_manifests
     config.manifest_paths.flat_map { |path|
-      JSON.parse(path.read).map { |_, entry| entry['file'] }
+      JSON.parse(path.read).flat_map { |_, entry| [entry['file']] + entry['css'] }
     }.compact.uniq.map { |path| config.build_output_dir.join(path).to_s }
   end
 


### PR DESCRIPTION
This was broken in https://github.com/ElMassimo/vite_ruby/commit/8a581c15ff480049bbb14dab1b5a3497308521b5 with no explanation of why it was being removed.

See #404 and #438 .