### PR TITLE
feat: change default execution to use `npx vite` instead

### DIFF
--- a/vite-plugin-ruby/default.vite.json
+++ b/vite-plugin-ruby/default.vite.json
@@ -16,7 +16,7 @@
   "https": null,
   "port": 3036,
   "hideBuildConsoleOutput": false,
-  "viteBinPath": "node_modules/.bin/vite",
+  "viteBinPath": null,
   "watchAdditionalPaths": [],
   "base": "",
   "ssrBuildEnabled": false,

--- a/vite_ruby/default.vite.json
+++ b/vite_ruby/default.vite.json
@@ -16,7 +16,7 @@
   "https": null,
   "port": 3036,
   "hideBuildConsoleOutput": false,
-  "viteBinPath": "node_modules/.bin/vite",
+  "viteBinPath": null,
   "watchAdditionalPaths": [],
   "base": "",
   "ssrBuildEnabled": false,

--- a/vite_ruby/lib/vite_ruby/cli/vite.rb
+++ b/vite_ruby/lib/vite_ruby/cli/vite.rb
@@ -5,6 +5,7 @@ class ViteRuby::CLI::Vite < Dry::CLI::Command
 
   def self.executable_options
     option(:mode, default: self::DEFAULT_ENV, values: %w[development production test], aliases: ['m'], desc: 'The build mode for Vite')
+    option(:node_options, desc: 'Node options for the Vite executable', aliases: ['node-options'])
     option(:inspect, desc: 'Run Vite in a debugging session with node --inspect-brk', aliases: ['inspect-brk'], type: :boolean)
     option(:trace_deprecation, desc: 'Run Vite in debugging mode with node --trace-deprecation', aliases: ['trace-deprecation'], type: :boolean)
   end
@@ -15,10 +16,20 @@ class ViteRuby::CLI::Vite < Dry::CLI::Command
     option(:clobber, desc: 'Clear cache and previous builds', type: :boolean, aliases: %w[clean clear])
   end
 
-  def call(mode:, args: [], clobber: false, **boolean_opts)
+  def call(mode:, args: [], clobber: false, node_options: nil, inspect: nil, trace_deprecation: nil, **boolean_opts)
     ViteRuby.env['VITE_RUBY_MODE'] = mode
     ViteRuby.commands.clobber if clobber
+
+    node_options = [
+      node_options,
+      ('--inspect-brk' if inspect),
+      ('--trace-deprecation' if trace_deprecation),
+    ].compact.join(' ')
+
+    args << %(--node-options="#{ node_options }") unless node_options.empty?
+
     boolean_opts.map { |name, value| args << "--#{ name }" if value }
+
     yield(args)
   end
 end


### PR DESCRIPTION
### Description 📖

This pull request changes the default behavior for executing `vite` to use the package manager instead.

For example, `npx vite` or `yarn vite`.

The [`viteBinPath`](https://vite-ruby.netlify.app/config/index.html#vitebinpath) will still be used if provided.

### Background 📜

`npm bin` was removed in `npm 9`.

In addition, unlike what happens in other ecosystems, JS is getting _more_ package managers:
- `npm`
- `pnpm`
- `yarn`
- `bun`
