### PR TITLE
feat: add `package_manager` config option, experimental support for bun

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -285,6 +285,18 @@ You can customize this behavior using the following options.
 
   Allows to skip Vite build output from logs, to keep the noise down.
 
+### packageManager
+
+- **Default:** auto-detected based on existing lockfiles, otherwise `"npm"`
+- **Env Var:** `VITE_RUBY_PACKAGE_MANAGER`
+
+  Allows to specify which package manager to use, such as:
+
+  - `npm`
+  - `pnpm`
+  - `yarn`
+  - `bun` (experimental)
+
 ### root
 
 - **Default:** `Rails.root`

--- a/vite-plugin-ruby/default.vite.json
+++ b/vite-plugin-ruby/default.vite.json
@@ -7,6 +7,7 @@
   "publicOutputDir": "vite",
   "configPath": "config/vite.json",
   "devServerConnectTimeout": 0.01,
+  "packageManager": null,
   "publicDir": "public",
   "entrypointsDir": "entrypoints",
   "sourceCodeDir": "app/frontend",

--- a/vite_ruby/default.vite.json
+++ b/vite_ruby/default.vite.json
@@ -7,6 +7,7 @@
   "publicOutputDir": "vite",
   "configPath": "config/vite.json",
   "devServerConnectTimeout": 0.01,
+  "packageManager": null,
   "publicDir": "public",
   "entrypointsDir": "entrypoints",
   "sourceCodeDir": "app/frontend",

--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -43,10 +43,13 @@ namespace :vite do
   desc 'Ensure build dependencies like Vite are installed before bundling'
   task :install_dependencies do
     install_env_args = ENV['VITE_RUBY_SKIP_INSTALL_DEV_DEPENDENCIES'] == 'true' ? {} : { 'NODE_ENV' => 'development' }
-    cmd = ViteRuby.commands.legacy_npm_version? ? 'npx ci --yes' : 'npx --yes ci'
-    result = system(install_env_args, cmd)
-    # Fallback to `yarn` if `npx` is not available.
-    system(install_env_args, 'yarn install --frozen-lockfile') if result.nil?
+
+    install_cmd = case (pkg = ViteRuby.config.package_manager)
+    when "npm" then "npm ci"
+    else "#{pkg} install --frozen-lockfile"
+    end
+
+    system(install_env_args, install_cmd)
   end
 
   desc "Provide information on ViteRuby's environment"

--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -45,8 +45,8 @@ namespace :vite do
     install_env_args = ENV['VITE_RUBY_SKIP_INSTALL_DEV_DEPENDENCIES'] == 'true' ? {} : { 'NODE_ENV' => 'development' }
 
     install_cmd = case (pkg = ViteRuby.config.package_manager)
-    when "npm" then "npm ci"
-    else "#{pkg} install --frozen-lockfile"
+    when 'npm' then 'npm ci'
+    else "#{ pkg } install --frozen-lockfile"
     end
 
     system(install_env_args, install_cmd)

--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -97,7 +97,7 @@ private
       FileUtils.mv root.join('vite.config.ts'), root.join('vite.config.mts'), force: true, verbose: true
     end
 
-    install_dependencies js_dependencies.join(' ')
+    install_js_packages js_dependencies.join(' ')
   end
 
   # Internal: Adds compilation output dirs to git ignore.
@@ -131,7 +131,7 @@ private
     end
   end
 
-  def install_dependencies(deps)
+  def install_js_packages(deps)
     run_with_capture("#{ config.package_manager } add -D #{ deps }", stdin_data: "\n")
   end
 

--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -6,7 +6,7 @@ require 'json'
 class ViteRuby::CLI::Install < Dry::CLI::Command
   desc 'Performs the initial configuration setup to get started with Vite Ruby.'
 
-  option(:package_manager, values: %w[npm pnpm yarn bun], aliases: ['package-manager'], desc: 'The package manager to use when installing JS dependencies.')
+  option(:package_manager, values: %w[npm pnpm yarn bun], aliases: %w[package-manager with], desc: 'The package manager to use when installing JS dependencies.')
 
   def call(package_manager: nil, **)
     ENV['VITE_RUBY_PACKAGE_MANAGER'] ||= package_manager if package_manager

--- a/vite_ruby/lib/vite_ruby/cli/install.rb
+++ b/vite_ruby/lib/vite_ruby/cli/install.rb
@@ -6,7 +6,11 @@ require 'json'
 class ViteRuby::CLI::Install < Dry::CLI::Command
   desc 'Performs the initial configuration setup to get started with Vite Ruby.'
 
-  def call(**)
+  option(:package_manager, values: %w[npm pnpm yarn bun], aliases: ['package-manager'], desc: 'The package manager to use when installing JS dependencies.')
+
+  def call(package_manager: nil, **)
+    ENV['VITE_RUBY_PACKAGE_MANAGER'] ||= package_manager if package_manager
+
     $stdout.sync = true
 
     say 'Creating binstub'
@@ -93,8 +97,7 @@ private
       FileUtils.mv root.join('vite.config.ts'), root.join('vite.config.mts'), force: true, verbose: true
     end
 
-    deps = js_dependencies.join(' ')
-    run_with_capture("#{ npm_install } -D #{ deps }", stdin_data: "\n")
+    install_dependencies js_dependencies.join(' ')
   end
 
   # Internal: Adds compilation output dirs to git ignore.
@@ -128,12 +131,8 @@ private
     end
   end
 
-  # Internal: Support all popular package managers.
-  def npm_install
-    return 'yarn add' if root.join('yarn.lock').exist?
-    return 'pnpm install' if root.join('pnpm-lock.yaml').exist?
-
-    'npm install'
+  def install_dependencies(deps)
+    run_with_capture("#{ config.package_manager } add -D #{ deps }", stdin_data: "\n")
   end
 
   # Internal: Avoid printing warning about missing vite.json, we will create one.

--- a/vite_ruby/lib/vite_ruby/cli/upgrade_packages.rb
+++ b/vite_ruby/lib/vite_ruby/cli/upgrade_packages.rb
@@ -5,7 +5,6 @@ class ViteRuby::CLI::UpgradePackages < ViteRuby::CLI::Install
 
   def call(**)
     say 'Upgrading npm packages'
-    deps = js_dependencies.join(' ')
-    run_with_capture("#{ npm_install } -D #{ deps }")
+    install_js_packages js_dependencies.join(' ')
   end
 end

--- a/vite_ruby/lib/vite_ruby/commands.rb
+++ b/vite_ruby/lib/vite_ruby/commands.rb
@@ -109,11 +109,11 @@ class ViteRuby::Commands
         $stdout.puts "#{ framework }: #{ Gem.loaded_specs[framework]&.version }"
       end
 
-      $stdout.puts "node: #{ `node --version` }"
-      $stdout.puts "npm: #{ `npm --version` }"
-      $stdout.puts "yarn: #{ `yarn --version` rescue nil }"
-      $stdout.puts "pnpm: #{ `pnpm --version` rescue nil }"
       $stdout.puts "ruby: #{ `ruby --version` }"
+      $stdout.puts "node: #{ `node --version` }"
+
+      pkg = config.package_manager
+      $stdout.puts "#{ pkg }: #{ `#{ pkg } --version` rescue nil }"
 
       $stdout.puts "\n"
       packages = `npm ls vite vite-plugin-ruby`


### PR DESCRIPTION
### Description 📖

This pull request adds a `package_manager` config option, allowing to explicitly specify which package manager should be used to install JS dependencies and execute Vite.

In addition, it can be provided during installation:

```ruby
bundle exec vite install --with pnpm
```

Finally, it adds experimental support for [bun](https://bun.sh/) now that it's 1.1.

### Background 📜

Closes:
- #324
