### PR TITLE
force ssr build when VITE_RUBY_SSR_BUILD_ENABLED=true

### DIFF
--- a/vite_ruby/lib/tasks/vite.rake
+++ b/vite_ruby/lib/tasks/vite.rake
@@ -22,7 +22,7 @@ namespace :vite do
   desc 'Bundle entrypoints using Vite Ruby (SSR only if enabled)'
   task build_all: :'vite:verify_install' do
     ViteRuby.commands.build_from_task
-    ViteRuby.commands.build_from_task('--ssr') if ViteRuby.config.ssr_build_enabled
+    ViteRuby.commands.build_from_task('--ssr', '--force') if ViteRuby.config.ssr_build_enabled
   end
 
   desc 'Remove old bundles created by ViteRuby'


### PR DESCRIPTION
### Description 📖

This pull request fixes #483

### Background 📜

This was happening because you need to force ssr build

### The Fix 🔨

By changing 
`ViteRuby.commands.build_from_task('--ssr') if ViteRuby.config.ssr_build_enabled`
 to 
`ViteRuby.commands.build_from_task('--ssr', '--force') if ViteRuby.config.ssr_build_enabled`

