### PR TITLE
fix: actually run vite inside bun

### DIFF
--- a/vite_ruby/lib/vite_ruby/runner.rb
+++ b/vite_ruby/lib/vite_ruby/runner.rb
@@ -43,7 +43,7 @@ private
     x = case config.package_manager
     when 'npm' then %w[npx]
     when 'pnpm' then %w[pnpm exec]
-    when 'bun' then %w[bun x]
+    when 'bun' then %w[bun x --bun]
     when 'yarn' then %w[yarn]
     else raise ArgumentError, "Unknown package manager #{ config.package_manager.inspect }"
     end


### PR DESCRIPTION
### Description 📖

Fixes the runner to actually use Bun and not Node

### Background 📜

When using bun, Runner would call into `bunx vite`, but the vite executable has a node shebang which bunx respects so vite would actually run inside node.

https://bun.sh/docs/cli/bunx#shebangs

### The Fix 🔨

This commit adds a --bun flag su that bunx ignores the node shebang.
