### PR TITLE
fix documentation for viteBinPath default value

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -335,10 +335,12 @@ You can customize this behavior using the following options.
 
 ### viteBinPath
 
-- **Default:** `node_modules/.bin/vite`
+- **Default:** `null`
 - **Env Var:** `VITE_RUBY_VITE_BIN_PATH`
 
   The path where the Vite.js binary is installed. It will be used to execute the `dev` and `build` commands.
+
+  These commands are executed by your package manager unless this variable is defined.
 
 ### watchAdditionalPaths
 


### PR DESCRIPTION
### Description 📖

This pull request corrects the default value of the `viteBinPath` configuration setting.

### Background 📜

The default is incorrectly given for the `viteBinPath` configuration setting after the change merged in #480.

### The Fix 🔨

By fixing the default in the documentation, misconfiguration and errors in build and deployment workflows are avoided.
