### PR TITLE
feat: allow proxy to run on multiple test environments

### DIFF
--- a/vite_ruby/lib/vite_ruby.rb
+++ b/vite_ruby/lib/vite_ruby.rb
@@ -107,7 +107,7 @@ class ViteRuby
 
   # Public: The proxy for assets should only run in development mode.
   def run_proxy?
-    config.mode == 'development' || (config.mode == 'test' && !ENV['CI'])
+    config.mode == 'development' || (config.mode.include?('test') && !ENV['CI'])
   rescue StandardError => error
     logger.error("Failed to check mode for Vite: #{ error.message }")
     false


### PR DESCRIPTION
### Description 📖

Allow proxy to run on multiple test environments.

### Background 📜

Let's say that you have multiple test environments with different configurations, e.g.
- `RAILS_ENV=test` - unit tests
- `RAILS_ENV=test_e2e` - end-to-end tests

You might want to be able to run the proxy server in each of these environments while developing or writing tests. With the current implementation of `run_proxy?`, the `ENV` name must match `"test"` exactly for the proxy to run.

### The Fix 🔨

This PR contains a simple, but potentially hacky fix - instead of an exact match, we check if `mode` contains the substring "test". It's hacky because `mode` can be any arbitrary string, e.g. `"greatest_production"`, that might unintentionally match the condition.

At the risk of bloat, a better way might be to add a config for it, let's say, `force_proxy`. 

Is there already a workaround for this? If not, what would be a suitable way to handle this? I'd be happy to see this PR through.

### Screenshots 📷
