### PR TITLE
Add `logger` as a runtime dependency rather than default gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
   specs:
     vite_ruby (3.8.2)
       dry-cli (>= 0.7, < 2)
+      logger (~> 1.6)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
 
@@ -120,6 +121,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.6.3)
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'dry-cli', '>= 0.7', '< 2'
   s.add_dependency 'rack-proxy', '~> 0.6', '>= 0.6.1'
   s.add_dependency 'zeitwerk', '~> 2.2'
+  s.add_dependency 'logger', '~> 1.6'
 
   s.add_development_dependency 'm', '~> 1.5'
   s.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
### Description 📖

The default gem `logger` will be removed from Ruby 3.5.0 and must now be installed separately. This also resolves a warning in Ruby 3.3.5.

### Background 📜

Ruby is removing some of the “default” gems so they now need to be installed separately.

### The Fix 🔨

I’ve added the `logger` gem as a runtime dependency.

### Screenshots 📷

I don’t have any screenshots, but I have a copy of the warning message in Ruby 3.3.5.

> warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.