### PR TITLE
Update CI to add rails 7.2 to test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,8 @@ jobs:
         gemfile: [
           "Gemfile-rails.6.1.x",
           "Gemfile-rails.7.0.x",
-          "Gemfile-rails.7.1.x"
+          "Gemfile-rails.7.1.x",
+          "Gemfile-rails.7.2.x",
         ]
         experimental: [false]
         include:

--- a/gemfiles/Gemfile-rails.7.2.x
+++ b/gemfiles/Gemfile-rails.7.2.x
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.2.0'
+
+gemspec path: '../vite_ruby'
+gemspec path: '../vite_rails'
+gemspec path: '../vite_plugin_legacy'


### PR DESCRIPTION
### Description 📖

Update CI to add rails 7.2 to test matrix

### Background 📜

Check change log, somehow also checked test matrix, found that rails 7.2 missing

### The Fix 🔨

Add it

### Screenshots 📷

N/A
