### PR TITLE
Update CI to use latest ruby for rubocop, use NodeJS 20.x

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: [
-          3.1
+          3.3
         ]
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Description 📖

Update CI to use latest ruby for rubocop, use NodeJS 20.x

### Background 📜

Saem as https://github.com/ElMassimo/vite_ruby/pull/503

### The Fix 🔨

Just update it

### Screenshots 📷
