### PR TITLE
fix: Do not override userConfig.server.origin on skipProxy=true

### DIFF
--- a/vite-plugin-ruby/src/config.ts
+++ b/vite-plugin-ruby/src/config.ts
@@ -89,9 +89,8 @@ function coerceConfigurationValues (config: ResolvedConfig, projectRoot: string,
 
   const server: ServerOptions = { fs, host: config.host, https, port, strictPort: true }
 
-  const originPresent = "server" in userConfig && "origin" in userConfig.server;
-  if (booleanOption(config.skipProxy) && !originPresent)
-    server.origin = `${https ? 'https' : 'http'}://${config.host}:${config.port}`
+  if (booleanOption(config.skipProxy))
+    server.origin = userConfig.server?.origin || `${https ? 'https' : 'http'}://${config.host}:${config.port}`
 
   // Connect directly to the Vite dev server, rack-proxy does not proxy websocket connections.
   const hmr = userConfig.server?.hmr ?? {}

--- a/vite-plugin-ruby/src/config.ts
+++ b/vite-plugin-ruby/src/config.ts
@@ -89,7 +89,8 @@ function coerceConfigurationValues (config: ResolvedConfig, projectRoot: string,
 
   const server: ServerOptions = { fs, host: config.host, https, port, strictPort: true }
 
-  if (booleanOption(config.skipProxy))
+  const originPresent = "server" in userConfig && "origin" in userConfig.server;
+  if (booleanOption(config.skipProxy) && !originPresent)
     server.origin = `${https ? 'https' : 'http'}://${config.host}:${config.port}`
 
   // Connect directly to the Vite dev server, rack-proxy does not proxy websocket connections.


### PR DESCRIPTION
### Description 📖

Do not override config.server.origin when the user provides it.

### Background 📜

Using Vite-ruby with docker compose has many pitfalls (see #391 but this one cannot be worked around.

### The Fix 🔨

Is pretty trivial as you'll see in the code

### Screenshots 📷

nope :sweat_smile: 
