### PR TITLE
Drop EOL rails version from CI config

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,6 @@ jobs:
           "3.3",
         ]
         gemfile: [
-          "Gemfile-rails.6.1.x",
           "Gemfile-rails.7.0.x",
           "Gemfile-rails.7.1.x",
           "Gemfile-rails.7.2.x",

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 6.1.0'
-
-gemspec path: '../vite_ruby'
-gemspec path: '../vite_rails'
-gemspec path: '../vite_plugin_legacy'


### PR DESCRIPTION
Version 6.1 is EOL as of either the beginning or end of this month, depending what you read. Drop from matrix.

Separately ... are these gemfiles/* files generated by hand, or with a tool?