### PR TITLE
Update `detect_package_manager` to look for new Bun lockfile

### DIFF
--- a/vite_ruby/lib/vite_ruby/config.rb
+++ b/vite_ruby/lib/vite_ruby/config.rb
@@ -108,7 +108,7 @@ private
   def detect_package_manager(root)
     return "npm" if root.join("package-lock.json").exist?
     return "pnpm" if root.join("pnpm-lock.yaml").exist?
-    return "bun" if root.join("bun.lockb").exist?
+    return "bun" if root.join("bun.lockb").exist? || root.join("bun.lock").exist?
     return "yarn" if root.join("yarn.lock").exist?
 
     "npm"


### PR DESCRIPTION
### Description 📖

Update the `detect_package_manager` method so that it looks for both Bun lockfile formats. Without this change, Bun setups that use [the new lockfile format](https://bun.sh/docs/install/lockfile#text-based-lockfile) could fail to build, since Vite Ruby would incorrectly think that `npm` was the desired package manager.

### Background 📜

Bun is in the process of switching from the binary `bun.lockb` file to a new, text-based `bun.lock` file. 

As of Bun 1.2, the new text-based lockfile is the default. We need to update the `detect_package_manager` to look for both lockfile formats, but we should be able to eventually retire the binary lockfile format.

More info: https://bun.sh/docs/install/lockfile#text-based-lockfile

### The Fix 🔨

By looking for the new lockfile format (as well as the old one), the `detect_package_manager` method will correctly state that Bun is the desired package manager for Bun setups that use the new lockfile format.

### Screenshots 📷

Here are excerpts of a failing deploy log:

```
Installed Bun v1.2.1
Installing dependencies...
bun install v1.2.1 (ce532901)
...
+ vite@5.4.11
+ vite-plugin-rails@0.5.0
...
-----> Preparing app for Rails asset pipeline
cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead
       Running: rake assets:precompile
       Building with Vite ⚡️

       rake aborted!
       ViteRuby::MissingExecutableError: ❌ The vite binary is not available. Have you installed the npm packages? (ViteRuby::MissingExecutableError)
       
       Visit the Troubleshooting guide for more information:
         https://vite-ruby.netlify.app/guide/troubleshooting.html#troubleshooting
       
       No such file or directory - npx
       /tmp/build/vendor/bundle/ruby/3.3.0/gems/vite_ruby-3.9.1/lib/vite_ruby/runner.rb:19:in `rescue in run'
```

This is the first deploy we've attempted since merging a PR that upgraded Bun to use the new lockfile format.