### PR TITLE
Fix typo in vite_rails/cli.rb

### DIFF
--- a/vite_rails/lib/vite_rails/cli.rb
+++ b/vite_rails/lib/vite_rails/cli.rb
@@ -24,7 +24,7 @@ end
 module ViteRails::CLI::Install
   RAILS_TEMPLATES = Pathname.new(File.expand_path("../../templates", __dir__))
 
-  # Override: Setup a typical apps/web Hanami app to use Vite.
+  # Override: Setup a typical apps/web Rails app to use Vite.
   def setup_app_files
     cp RAILS_TEMPLATES.join("config/rails-vite.json"), config.config_path
     if dir = %w[app/javascript app/packs].find { |path| root.join(path).exist? }


### PR DESCRIPTION
At [line 27 in `vite_rails/lib/vite_rails/cli.rb`](https://github.com/ElMassimo/vite_ruby/blob/95c247a66d86f15ad9ce783acf92fef96646091b/vite_rails/lib/vite_rails/cli.rb#L27), correct Hanami to Rails:

```rb
- # Override: Setup a typical apps/web Hanami app to use Vite.
```

```rb
+ # Override: Setup a typical apps/web Rails app to use Vite.
```