### PR TITLE
docs: improve grammar of sentence in migration guide

### DIFF
--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -46,7 +46,7 @@ Have in mind that this is optional, as both approaches can coexist without issue
 
 When migrating from [Webpacker], start by following the [guide] to get a [basic setup][sourceCodeDir] working before proceeding to migrate existing code.
 
-During installation, Vite Ruby detect if the `app/javascript` directory exists,
+During installation, Vite Ruby checks if the `app/javascript` directory exists,
 and use that in your `config/vite.json` instead of the [default][sourceCodeDir].
 
 ```json


### PR DESCRIPTION
### Description 📖

This pull request improves the grammar of a sentence in the migration guide

### Background 📜

This was happening because I was reading the guide, and noticed this sentence didn't make sense

### The Fix 🔨

By changing the pluralization of the word, it now makes more sense.

I also changed the word itself as it ends up having the same number of characters and I think reads a little more naturally

### Screenshots 📷
