### PR TITLE
feat: support advanced entrypoints

### DIFF
--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -152,6 +152,26 @@ class ManifestTest < ViteRuby::Test
     assert_equal lookup!("entrypoints/main", type: :typescript), lookup!("main.ts")
   end
 
+  def test_custom_name_lookup_success!
+    entry = {
+      "file" => prefixed("main.CkQYLEXT.js"),
+      "name" => "entrypoints/custom-name",
+      "src" => "entrypoints/main.js",
+      "isEntry" => true,
+    }
+
+    assert_equal entry, lookup!("custom-name", type: :javascript)
+  end
+
+  def test_css_lookup_success!
+    entry = {
+      "isEntry" => true,
+      "file" => prefixed("application-ru2hYTUX.css"),
+    }
+
+    assert_equal entry, lookup!("stylesheets/application.css", type: :stylesheet)
+  end
+
   def test_lookup_success_with_dev_server_running!
     refresh_config(mode: "development")
     with_dev_server_running {

--- a/test/test_app/public/vite-production/.vite/manifest.json
+++ b/test/test_app/public/vite-production/.vite/manifest.json
@@ -89,6 +89,20 @@
       "assets/theme.e6d9734b.css"
     ]
   },
+  "entrypoints/main.js": {
+    "file": "assets/main.CkQYLEXT.js",
+    "name": "entrypoints/custom-name",
+    "src": "entrypoints/main.js",
+    "isEntry": true
+  },
+  "stylesheets/application.scss": {
+    "file": "assets/application-ru2hYTUX.css",
+    "src": "stylesheets/application.scss",
+    "isEntry": true,
+    "names": [
+      "stylesheets/application.css"
+    ]
+  },
   "../assets/external.js": {
     "file": "assets/external.d1ae13f1.js",
     "src": "../assets/external.js",


### PR DESCRIPTION
### Description 📖

This change adds support for more advanced entrypoints:

1. Entrypoints with custom names that don't match the file name
2. CSS-only entrypoints

Example config for custom names:

```js
{
  build: {
    rollupOptions: {
      input: {
        'custom-name': '/some-other-file.js'
      }
    }
  }
}
```

Example config for CSS only entrypoint:

```js
{
  build: {
    rollupOptions: {
      input: {
        'my-style': '/some-style.scss'
      }
    }
  }
}
```

### Background 📜

At GitLab we have entrypoints that don't necessarily match the filenames. This is due to how we change the entrypoints based on the target release: community edition (CE) or enterprise (EE). EE entrypoints are resolved outside of the `sourceCodeDir` and thus don't match exactly the filename. Also, we use special names for those: `pages/foo/bar/index.js` will get a name `pages.foo.bar`. As you can see it can not be directly matched to the filename. That's why we need to respect the `name` property stored in the manifest and use it instead or the actual filename to resolve an asset.

The same thing applies to the stylesheets, we could have different name for these. So we have to resolve CSS entrypoints using `names` property, which as added in https://github.com/vitejs/vite/pull/19912 and released in https://github.com/vitejs/vite/releases/tag/v7.0.0-beta.0.

### The Fix 🔨

We fix the issue by using `name` and `names` property for entries with `isEntry` field. For such entries we create new records in the manifest with `name` (or each key in `names`) used as a primary key.

