### PR TITLE
Changes required to unbreak vite-rolldown

### DIFF
--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -45,6 +45,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
     rollupInput = { [rollupInput]: rollupInput }
 
   // Detect if we're using rolldown
+  // @ts-ignore - Vite plugin context provides meta information
   const isUsingRolldown = this.meta && this.meta.rolldownVersion;
   const optionsKey = isUsingRolldown ? "rolldownOptions" : "rollupOptions";
 


### PR DESCRIPTION
### Description 📖

This pull request contains changes to this plugin so that running vite with rolldown still works. I believe we're not inserting the correct entries into `rolldownOptions` causing us to run into this issue: https://github.com/vitejs/rolldown-vite/issues/371

### Background 📜

Since rolldown-vite expects `rolldownOptions` instead of `rollupOptions` and somehow both are present when the plugin in the current state is run, `rollupOptions` gets discarded, which means all the settings built up from the `config` function get dropped (e.g entrypoints)

### The Fix 🔨

This fix detects whether we're using rolldown and sets the options appropriately. In addition, I attempted to fix an issue where `outputFileName` was being passed an undefined value , causing vite to fail building assets. Once I added `if (typeof name === "undefined") return "";` - everything started building again. 
