### PR TITLE
Early Hints links should be separated by a comma

### DIFF
--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -107,7 +107,7 @@ private
       :send_early_hints,
       "Link" => asset_paths.map { |href|
         %(<#{href}>; rel=modulepreload; as=script; crossorigin=#{crossorigin})
-      }.join("\n"),
+      }.join(","),
     )
     asset_paths.map { |href|
       tag.link(rel: "modulepreload", href: href, as: "script", crossorigin: crossorigin, **options)


### PR DESCRIPTION
### Description 📖

This pull request changes how multiple 103 Early Hints links are concatenated. Instead of using a newline, it should be comma separated.

### Background 📜

This was fixed in Rails: https://github.com/rails/rails/commit/3922460df7a7b2ba1b2898e428be96a8e52380e9