### PR TITLE
Fix Vite 6 compatibility: Check for 'this' before accessing this.meta

### DIFF
--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -46,7 +46,7 @@ function config (userConfig: UserConfig, env: ConfigEnv): UserConfig {
 
   // Detect if we're using rolldown
   // @ts-ignore - Vite plugin context provides meta information
-  const isUsingRolldown = this.meta && this.meta.rolldownVersion;
+  const isUsingRolldown = this && this.meta && this.meta.rolldownVersion;
   const optionsKey = isUsingRolldown ? "rolldownOptions" : "rollupOptions";
 
   const build = {


### PR DESCRIPTION
Vite 6 changed how it invokes plugin hooks - the config hook no longer receives the plugin context (this). This causes 'TypeError: undefined is not an object (evaluating this.meta)' when using Vite 6.

This fix adds a null check for 'this' before accessing this.meta to maintain compatibility with both Vite 5 and Vite 6.

Fixes: TypeError when starting Vite 6 dev server
Tested with: Vite 6.4.1, vite_ruby 3.9.2, Rails 8.0.4
