### PR TITLE
fix: Allow new Vite v8 `outputOptions` callback shape

### DIFF
--- a/vite-plugin-ruby/src/index.ts
+++ b/vite-plugin-ruby/src/index.ts
@@ -9,6 +9,15 @@ import { assetsManifestPlugin } from './manifest'
 
 export * from './types'
 
+export interface PreRenderedAsset {
+  type: 'asset'
+  name?: string // Vite v7, deprecated
+  names?: string[] // Vite v8
+  originalFileName?: string // Vite v7, deprecated
+  originalFileNames?: string[] // Vite v8
+  source: string | Uint8Array
+}
+
 // Public: The resolved project root.
 export const projectRoot = configOptionFromEnv('root') || process.cwd()
 
@@ -107,9 +116,10 @@ function configureServer (server: ViteDevServer) {
 
 function outputOptions (assetsDir: string, ssrBuild: boolean) {
   // Internal: Avoid nesting entrypoints unnecessarily.
-  const outputFileName = (ext: string) => ({ name }: { name: string }) => {
-    if (typeof name === 'undefined') return ''
-    const shortName = basename(name).split('.')[0]
+  const outputFileName = (ext: string) => (asset: PreRenderedAsset) => {
+    // Vite v8 uses `names`, earlier versions use `name`
+    const resolvedName = asset.names?.[0] ?? asset.name ?? '[name]'
+    const shortName = basename(resolvedName).split('.')[0]
     return posix.join(assetsDir, `${shortName}-[hash].${ext}`)
   }
 

--- a/vite-plugin-ruby/tests/index.spec.ts
+++ b/vite-plugin-ruby/tests/index.spec.ts
@@ -28,4 +28,34 @@ describe('config', () => {
       pluginConfig({ ...defaultConfig, build: { ssr: true } }, { mode: 'production' })
     }).toThrow('No SSR entrypoint available')
   })
+
+  describe('outputFileName (assetFileNames)', () => {
+    function getAssetFileNames () {
+      const plugin = ViteRuby()
+      const pluginConfig = plugin[0].config
+      defaultConfig.configPath = './default.vite.json'
+      const result = pluginConfig(defaultConfig, { mode: 'production' })
+      return result.build.rollupOptions.output.assetFileNames as (asset: any) => string
+    }
+
+    const source = 'content'
+
+    test('legacy `name` shape (Vite v7)', () => {
+      const assetFileNames = getAssetFileNames()
+      const result = assetFileNames({ type: 'asset', name: 'application.css', source })
+      expect(result).toMatch(/^assets\/application-[^.]+\.\[ext\]$/)
+    })
+
+    test('new `names` shape (Vite v8)', () => {
+      const assetFileNames = getAssetFileNames()
+      const result = assetFileNames({ type: 'asset', names: ['application.css'], originalFileNames: [], source })
+      expect(result).toMatch(/^assets\/application-[^.]+\.\[ext\]$/)
+    })
+
+    test('falls back to `[name]` placeholder when both are absent', () => {
+      const assetFileNames = getAssetFileNames()
+      const result = assetFileNames({ type: 'asset', source })
+      expect(result).toBe('assets/[name]-[hash].[ext]')
+    })
+  })
 })


### PR DESCRIPTION
### Description 📖

Fix a build issue related to Vite 8's handling of the `assetFileNames` callback, which is manually typed in the `outputFileName()` function.

### Background 📜

Vite v8 (which uses Rolldown) changed the object shape passed to the `assetFileNames` callback.

In Vite v7 (which uses Rollup), the callback received a `PreRenderedAsset` object with a singular `name: string | undefined` field.

In Vite v8, Vite's internal `vite:css-post` plugin calls the same `assetFileNames` function with a plural `names: string[]` field instead. This matches the Rolldown `PreRenderedAsset` interface. See: https://github.com/rolldown/rolldown/blob/a71934bf/packages/rolldown/src/options/output-options.ts#L66-L77

### The Fix 🔨

First, we define a `PreRenderedAsset` interface that handles both shapes:

```ts
export interface PreRenderedAsset {
  name?: string // Vite v7, deprecated
  names?: string[] // Vite v8
  // ...
}
```

Then, determine which value to use within the `outputFileName()` function:

```ts
const outputFileName = (ext: string) => (asset: PreRenderedAsset) => {
    // Vite v8 uses `names`, earlier versions use `name`
    const resolvedName = asset.names?.[0] ?? asset.name ?? '[name]'
    const shortName = basename(resolvedName).split('.')[0]
    return posix.join(assetsDir, `${shortName}-[hash].${ext}`)
  }
```

### Screenshots 📷

A Rails project with `vite_rails` (3.0.19) and `vite_ruby` (3.9.2) began to fail after updating `vite` from 7.3.2 to 8.0.10:

<img width="1510" height="708" alt="Screenshot 2026-04-23 at 11 42 10 AM" src="https://github.com/user-attachments/assets/937e5fa5-6a1d-4f37-9027-5eab389ef9a0" />