### PR TITLE
chore: bump rack-proxy from 0.7.7 to 0.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
       stringio
     racc (1.8.1)
     rack (3.2.6)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.2)
       base64 (>= 0.1.0)


### PR DESCRIPTION
### Description 📖

This pull request bumps rack-proxy to pick up rack's security fixes.

### Background 📜

rack-proxy 0.7.7 is still using Rack 3.0.8 which relates to a few CVEs.

### The Fix 🔨

By bumping rack-proxy from 0.7.7 to 0.8.2.

ref: https://github.com/ncr/rack-proxy/pull/120

### Screenshots 📷
