### PR TITLE
fix: stop overriding Rails' media default in vite_javascript_tag

### DIFF
--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -41,7 +41,7 @@ module ViteRails::TagHelpers
     skip_preload_tags: false,
     skip_style_tags: false,
     crossorigin: "",
-    media: "screen",
+    media: nil,
     **options)
     entries = vite_manifest.resolve_entries(*names, type: asset_type)
     tags = javascript_include_tag(*entries.fetch(:scripts), crossorigin: crossorigin, type: type, extname: false, **options)

--- a/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
@@ -37,7 +37,7 @@ module ViteRailsLegacy::TagHelpers
     skip_preload_tags: false,
     skip_style_tags: false,
     crossorigin: "anonymous",
-    media: "screen",
+    media: nil,
     **options)
     entries = vite_manifest.resolve_entries(*names, type: asset_type)
     tags = javascript_include_tag(*entries.fetch(:scripts), crossorigin: crossorigin, type: type, extname: false, **options)

--- a/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
+++ b/vite_rails_legacy/lib/vite_rails_legacy/tag_helpers.rb
@@ -37,7 +37,7 @@ module ViteRailsLegacy::TagHelpers
     skip_preload_tags: false,
     skip_style_tags: false,
     crossorigin: "anonymous",
-    media: nil,
+    media: "screen",
     **options)
     entries = vite_manifest.resolve_entries(*names, type: asset_type)
     tags = javascript_include_tag(*entries.fetch(:scripts), crossorigin: crossorigin, type: type, extname: false, **options)


### PR DESCRIPTION
### Description 📖
Removes the hardcoded `media: "screen"` default from `vite_javascript_tag` so it defers to Rails' own `apply_stylesheet_media_default` setting instead of overriding it.

Fixes #535

### Background 📜
Rails introduced `config.action_view.apply_stylesheet_media_default` to let apps opt out of the legacy `media="screen"` behavior. Because `vite_javascript_tag` was explicitly passing `media: "screen"` to `stylesheet_link_tag`, though, this config had no effect on stylesheet tags generated by Vite entrypoints. Users who set `apply_stylesheet_media_default = false` were still getting `media="screen"`.

### The Fix 🔨
`vite_javascript_tag` now passes `media: nil` instead of `media: "screen"`, so `stylesheet_link_tag` controls the attribute. When `apply_stylesheet_media_default` is `true` (the Rails default), behavior is unchanged. When it's `false`, no `media` attribute is rendered. Callers can still pass an explicit `media:` value if needed.

The change covers both `vite_rails` and `vite_rails_legacy`.

### Screenshots 📷
