### PR TITLE
fix(vite-plugin-ruby): reuse an already-emitted asset instead of fingerprinting it twice

### DIFF
--- a/vite-plugin-ruby/src/manifest.ts
+++ b/vite-plugin-ruby/src/manifest.ts
@@ -4,9 +4,10 @@ import { createDebug } from 'obug'
 
 import type { Plugin, ResolvedConfig } from 'vite'
 
-import type { OutputBundle, PluginContext } from 'rollup'
+import type { OutputBundle, OutputAsset, PluginContext } from 'rollup'
 import { UnifiedConfig } from './types'
 import { filterEntrypointAssets } from './config'
+import { slash } from './utils'
 
 const debug = createDebug('vite-plugin-ruby:assets-manifest')
 
@@ -16,6 +17,33 @@ interface AssetsManifestChunk {
 }
 
 type AssetsManifest = Map<string, AssetsManifestChunk>
+
+// Internal: Older Rollup types don't know about the `names`/`originalFileNames`
+// arrays introduced for Vite v8, so we widen the shape locally instead of
+// bumping the (type-only) `rollup` dependency.
+type EmittedOutputAsset = OutputAsset & { originalFileNames?: string[] }
+
+// Internal: Finds an asset that Vite's own build pipeline already emitted for
+// this exact source file (e.g. because it's also imported from JS/CSS, or
+// referenced from an HTML entrypoint), so we can reuse its hashed file name.
+//
+// Emitting the same file a second time isn't safe to assume idempotent: two
+// independent `emitFile` calls for byte-identical content aren't guaranteed to
+// resolve to the same hash (this differs between Rollup and Rolldown), and
+// when they don't, only one of the two hashed files actually ends up on disk.
+// Reusing the existing entry sidesteps the mismatch entirely, and also avoids
+// writing the same asset to disk twice.
+function findExistingAsset (bundle: OutputBundle, absoluteFilename: string): string | undefined {
+  const normalizedFilename = slash(absoluteFilename)
+
+  for (const chunk of Object.values(bundle)) {
+    if (chunk.type !== 'asset') continue
+
+    const asset = chunk as EmittedOutputAsset
+    const originalFileNames = asset.originalFileNames ?? (asset.originalFileName ? [asset.originalFileName] : [])
+    if (originalFileNames.some(fileName => slash(fileName) === normalizedFilename)) return asset.fileName
+  }
+}
 
 // Internal: Writes a manifest file that allows to map an entrypoint asset file
 // name to the corresponding output file name.
@@ -29,11 +57,15 @@ export function assetsManifestPlugin (): Plugin {
     const remainingAssets = filterEntrypointAssets(viteRubyConfig.entrypoints)
 
     for (const [filename, absoluteFilename] of remainingAssets) {
-      const content = await fsp.readFile(absoluteFilename)
-      const ref = ctx.emitFile({ name: path.basename(filename), type: 'asset', source: content })
-      const hashedFilename = ctx.getFileName(ref)
+      const hashedFilename = findExistingAsset(bundle, absoluteFilename) ?? await emitAsset(ctx, filename, absoluteFilename)
       manifest.set(path.relative(config.root, absoluteFilename), { file: hashedFilename, src: filename })
     }
+  }
+
+  async function emitAsset (ctx: PluginContext, filename: string, absoluteFilename: string) {
+    const content = await fsp.readFile(absoluteFilename)
+    const ref = ctx.emitFile({ name: path.basename(filename), type: 'asset', source: content })
+    return ctx.getFileName(ref)
   }
 
   return {

--- a/vite-plugin-ruby/src/manifest.ts
+++ b/vite-plugin-ruby/src/manifest.ts
@@ -33,15 +33,20 @@ type EmittedOutputAsset = OutputAsset & { originalFileNames?: string[] }
 // when they don't, only one of the two hashed files actually ends up on disk.
 // Reusing the existing entry sidesteps the mismatch entirely, and also avoids
 // writing the same asset to disk twice.
-function findExistingAsset (bundle: OutputBundle, absoluteFilename: string): string | undefined {
+function findExistingAsset (bundle: OutputBundle, root: string, absoluteFilename: string): string | undefined {
   const normalizedFilename = slash(absoluteFilename)
+
+  // Rollup documents `originalFileNames` as absolute paths, but Rolldown (Vite
+  // v8's default bundler) can report them relative to `config.root` instead.
+  const resolveOriginalFileName = (fileName: string) =>
+    slash(path.isAbsolute(fileName) ? fileName : path.resolve(root, fileName))
 
   for (const chunk of Object.values(bundle)) {
     if (chunk.type !== 'asset') continue
 
     const asset = chunk as EmittedOutputAsset
     const originalFileNames = asset.originalFileNames ?? (asset.originalFileName ? [asset.originalFileName] : [])
-    if (originalFileNames.some(fileName => slash(fileName) === normalizedFilename)) return asset.fileName
+    if (originalFileNames.some(fileName => resolveOriginalFileName(fileName) === normalizedFilename)) return asset.fileName
   }
 }
 
@@ -57,7 +62,7 @@ export function assetsManifestPlugin (): Plugin {
     const remainingAssets = filterEntrypointAssets(viteRubyConfig.entrypoints)
 
     for (const [filename, absoluteFilename] of remainingAssets) {
-      const hashedFilename = findExistingAsset(bundle, absoluteFilename) ?? await emitAsset(ctx, filename, absoluteFilename)
+      const hashedFilename = findExistingAsset(bundle, config.root, absoluteFilename) ?? await emitAsset(ctx, filename, absoluteFilename)
       manifest.set(path.relative(config.root, absoluteFilename), { file: hashedFilename, src: filename })
     }
   }

--- a/vite-plugin-ruby/tests/manifest.spec.ts
+++ b/vite-plugin-ruby/tests/manifest.spec.ts
@@ -1,0 +1,111 @@
+import { resolve } from 'path'
+import { describe, test, expect, vi } from 'vitest'
+import type { OutputBundle } from 'rollup'
+import { assetsManifestPlugin } from '@plugin/manifest'
+
+describe('assetsManifestPlugin', () => {
+  const root = resolve('example/app/frontend')
+
+  function setup (entrypoints: [string, string][]) {
+    const plugin = assetsManifestPlugin()
+
+    ;(plugin.configResolved as any)({
+      root,
+      build: { manifest: true },
+      viteRuby: { entrypoints },
+    })
+
+    const emitFile = vi.fn(() => 'ref')
+    const getFileName = vi.fn(() => 'assets/re-fingerprinted-hash.svg')
+    const ctx: any = { emitFile, getFileName }
+
+    return { plugin, ctx, emitFile, getFileName }
+  }
+
+  function manifestAssetsSource (emitFile: ReturnType<typeof vi.fn>) {
+    const call = emitFile.mock.calls.find(([asset]) => asset.fileName === '.vite/manifest-assets.json')
+    return JSON.parse(call![0].source)
+  }
+
+  test('reuses an asset Vite already emitted for the same source file, instead of fingerprinting it again', async () => {
+    const absoluteFilename = resolve(root, 'images/logo.svg')
+    const { plugin, ctx, emitFile, getFileName } = setup([['images/logo.svg', absoluteFilename]])
+
+    // Simulates Vite/Rolldown having already emitted this exact file elsewhere
+    // in the bundle (e.g. it's also imported from JS or referenced from HTML).
+    const bundle = {
+      'assets/logo-existingHash.svg': {
+        type: 'asset',
+        fileName: 'assets/logo-existingHash.svg',
+        originalFileNames: [absoluteFilename],
+        source: '',
+      },
+    } as unknown as OutputBundle
+
+    await (plugin.generateBundle as any).call(ctx, {}, bundle)
+
+    // Re-emitting the same content isn't guaranteed to resolve to the same
+    // hash (this can differ between Rollup and Rolldown), so the existing
+    // entry must be reused rather than fingerprinted a second time.
+    expect(getFileName).not.toHaveBeenCalled()
+    expect(manifestAssetsSource(emitFile)).toEqual({
+      'images/logo.svg': { file: 'assets/logo-existingHash.svg', src: 'images/logo.svg' },
+    })
+  })
+
+  test('fingerprints the asset when Vite has not already emitted it elsewhere', async () => {
+    const absoluteFilename = resolve(root, 'images/logo.svg')
+    const { plugin, ctx, emitFile, getFileName } = setup([['images/logo.svg', absoluteFilename]])
+
+    const bundle = {} as OutputBundle
+
+    await (plugin.generateBundle as any).call(ctx, {}, bundle)
+
+    expect(getFileName).toHaveBeenCalledTimes(1)
+    expect(manifestAssetsSource(emitFile)).toEqual({
+      'images/logo.svg': { file: 'assets/re-fingerprinted-hash.svg', src: 'images/logo.svg' },
+    })
+  })
+
+  test('does not match an asset emitted for a different source file', async () => {
+    const absoluteFilename = resolve(root, 'images/logo.svg')
+    const { plugin, ctx, emitFile, getFileName } = setup([['images/logo.svg', absoluteFilename]])
+
+    const bundle = {
+      'assets/other-hash.svg': {
+        type: 'asset',
+        fileName: 'assets/other-hash.svg',
+        originalFileNames: [resolve(root, 'images/other.svg')],
+        source: '',
+      },
+    } as unknown as OutputBundle
+
+    await (plugin.generateBundle as any).call(ctx, {}, bundle)
+
+    expect(getFileName).toHaveBeenCalledTimes(1)
+    expect(manifestAssetsSource(emitFile)).toEqual({
+      'images/logo.svg': { file: 'assets/re-fingerprinted-hash.svg', src: 'images/logo.svg' },
+    })
+  })
+
+  test('supports the legacy singular `originalFileName` (pre-Vite-v8 shape)', async () => {
+    const absoluteFilename = resolve(root, 'images/logo.svg')
+    const { plugin, ctx, emitFile, getFileName } = setup([['images/logo.svg', absoluteFilename]])
+
+    const bundle = {
+      'assets/logo-existingHash.svg': {
+        type: 'asset',
+        fileName: 'assets/logo-existingHash.svg',
+        originalFileName: absoluteFilename,
+        source: '',
+      },
+    } as unknown as OutputBundle
+
+    await (plugin.generateBundle as any).call(ctx, {}, bundle)
+
+    expect(getFileName).not.toHaveBeenCalled()
+    expect(manifestAssetsSource(emitFile)).toEqual({
+      'images/logo.svg': { file: 'assets/logo-existingHash.svg', src: 'images/logo.svg' },
+    })
+  })
+})

--- a/vite-plugin-ruby/tests/manifest.spec.ts
+++ b/vite-plugin-ruby/tests/manifest.spec.ts
@@ -88,6 +88,27 @@ describe('assetsManifestPlugin', () => {
     })
   })
 
+  test('resolves `originalFileNames` reported relative to config.root (observed with Rolldown)', async () => {
+    const absoluteFilename = resolve(root, 'images/logo.svg')
+    const { plugin, ctx, emitFile, getFileName } = setup([['images/logo.svg', absoluteFilename]])
+
+    const bundle = {
+      'assets/logo-existingHash.svg': {
+        type: 'asset',
+        fileName: 'assets/logo-existingHash.svg',
+        originalFileNames: ['images/logo.svg'],
+        source: '',
+      },
+    } as unknown as OutputBundle
+
+    await (plugin.generateBundle as any).call(ctx, {}, bundle)
+
+    expect(getFileName).not.toHaveBeenCalled()
+    expect(manifestAssetsSource(emitFile)).toEqual({
+      'images/logo.svg': { file: 'assets/logo-existingHash.svg', src: 'images/logo.svg' },
+    })
+  })
+
   test('supports the legacy singular `originalFileName` (pre-Vite-v8 shape)', async () => {
     const absoluteFilename = resolve(root, 'images/logo.svg')
     const { plugin, ctx, emitFile, getFileName } = setup([['images/logo.svg', absoluteFilename]])


### PR DESCRIPTION
## Summary

Closes #611.

`fingerprintRemainingAssets` unconditionally re-reads and re-`emitFile`s every asset matched by `additionalEntrypoints` (the default `~/{assets,fonts,icons,images}/**/*` glob), even when the exact same file was already emitted once by Vite's own asset pipeline — e.g. because it's also `import`ed from JS/CSS, or referenced from an HTML entrypoint.

Two independent `emitFile` calls for byte-identical content aren't guaranteed to resolve to the same content hash. In a production app that upgraded from Vite 7 to Vite 8 (which defaults to Rolldown instead of Rollup), this manifested as:

```
$ grep -o 'bluethumb-nav-logo[^"]*' public/vite/.vite/manifest.json | sort -u
bluethumb-nav-logo-hxTv2K1u.svg

$ grep -o 'bluethumb-nav-logo[^"]*' public/vite/.vite/manifest-assets.json | sort -u
bluethumb-nav-logo-hxTv2K1u2.svg

$ find public/vite -iname '*nav-logo*'
public/vite/assets/bluethumb-nav-logo-hxTv2K1u.svg
```

Same source file, two different hashes across `manifest.json` and `manifest-assets.json`, and only one of the two ever gets written to disk. Since `ViteRuby::Manifest#load_manifest` merges manifest files with `Hash#merge` and `manifest-assets.json` is loaded last, it wins — so `vite_asset_path` resolves to a file that doesn't exist, and Rails 404s. Full repro and versions are in #611.

## Fix

Before fingerprinting a `remainingAsset`, scan the `bundle` for an `OutputAsset` whose `originalFileNames` (or the deprecated singular `originalFileName`) already contains the source path, and reuse its `fileName` instead of emitting again. This sidesteps the hash-mismatch entirely, regardless of which bundler is in use, and also avoids writing the same file to the output directory twice when it's already covered by Vite's own pipeline.

**Second commit — found while verifying against the real app:** the first version of this fix compared `originalFileNames` directly against the absolute source path, per Rollup's documented (and typed) contract that `originalFileNames` are absolute. I pointed the reporting app's `package.json` at this branch to confirm the fix before writing this up, and the mismatch still reproduced — the lookup never matched. Turned out Rolldown doesn't always honor that contract: for the specific asset from the report (matched by `additionalEntrypoints` *and* imported from a Vue SFC), it reported `originalFileNames: ["assets/bluethumb-nav-logo.svg"]` — relative to `config.root`, not absolute. The second commit resolves non-absolute entries against `config.root` before comparing, with a regression test for that exact shape.

## Test plan

- [x] Added `vite-plugin-ruby/tests/manifest.spec.ts`, unit-testing `assetsManifestPlugin` directly against a fake `bundle`/`PluginContext` — including a case with `originalFileNames` relative to `config.root`. Confirmed each case is red without its corresponding piece of the fix, green with it.
- [x] `pnpm -C vite-plugin-ruby build && pnpm -C vite-plugin-ruby test --run` — 17/17 passing.
- [x] `pnpm -C vite-plugin-ruby lint` on the touched files — clean.
- [x] `pnpm -r build && pnpm -C vite-plugin-rails test --run` against `examples/rails` (Vite 8) — `images/logo.png` (matched by both `additionalEntrypoints` and the `index.html` `<link>` tag) resolves to the same hash in both manifests before and after the fix in this fixture, so no regression there. I wasn't able to get this specific example to reproduce the hash *mismatch* itself, which is why the unit tests above exercise the dedup logic directly.
- [x] **Verified end-to-end against the real reporting app** (the one from #611): pointed its `package.json` at this branch, ran `RAILS_ENV=production bin/vite build` from a clean `public/vite` twice in a row — `manifest.json` and `manifest-assets.json` now agree on a single hash for the previously-mismatched asset, the file exists on disk, and it serves `HTTP 200` from a running Rails server.
- [ ] `tests/build.spec.ts`'s snapshot test failed for me on both `main` and this branch with an unrelated chunk-hash diff for `vue.js` (`vue-CoJ_KGkH.js` vs a freshly-built hash) — pre-existing flakiness in my local environment, not caused by this change.
