### PR TITLE
fix: update Vite Ruby gems conservatively

### DIFF
--- a/test/upgrade_test.rb
+++ b/test/upgrade_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UpgradeTest < ViteRuby::Test
+  def test_updates_gems_conservatively
+    libraries = [
+      ["rails", Struct.new(:name).new("vite_rails")],
+      ["rack", Struct.new(:name).new("vite_plugin_legacy")],
+    ]
+    status = MockProcessStatus.new
+
+    ViteRuby.stub(:framework_libraries, libraries) do
+      ViteRuby::IO.stub(:capture, ->(*command) {
+        assert_equal ["bundle update --conservative vite_ruby vite_rails vite_plugin_legacy"], command
+        ["", "", status]
+      }) do
+        ViteRuby::CLI::Upgrade.new.send(:upgrade_ruby_gems)
+      end
+    end
+  end
+end

--- a/vite_ruby/lib/vite_ruby/cli/upgrade.rb
+++ b/vite_ruby/lib/vite_ruby/cli/upgrade.rb
@@ -15,7 +15,7 @@ protected
 
     libraries = ViteRuby.framework_libraries.map { |_f, library| library.name }
 
-    run_with_capture("bundle update #{libraries.join(" ")}")
+    run_with_capture("bundle update --conservative vite_ruby #{libraries.join(" ")}")
   end
 
   # NOTE: Spawn a new process so that it uses the updated vite_ruby.


### PR DESCRIPTION
`vite upgrade` currently runs `bundle update` without `--conservative`, which can cause unnecessary indirect gem updates and broader lockfile changes.

This change uses `--conservative` and explicitly targets `vite_ruby` so the core gem is still upgraded. It also adds a regression test.