### PR TITLE
fix: allow secure rack-proxy releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       dry-cli (>= 0.7, < 2)
       logger (~> 1.6)
       mutex_m
-      rack-proxy (~> 0.6, >= 0.6.1)
+      rack-proxy (>= 0.6.1, < 2)
       zeitwerk (~> 2.2)
 
 GEM

--- a/vite_ruby/vite_ruby.gemspec
+++ b/vite_ruby/vite_ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "dry-cli", ">= 0.7", "< 2"
   s.add_dependency "logger", "~> 1.6"
   s.add_dependency "mutex_m"
-  s.add_dependency "rack-proxy", "~> 0.6", ">= 0.6.1"
+  s.add_dependency "rack-proxy", ">= 0.6.1", "< 2"
   s.add_dependency "zeitwerk", "~> 2.2"
 
   s.add_development_dependency "m", "~> 1.5"


### PR DESCRIPTION
## Summary

Relax the `rack-proxy` runtime dependency from `~> 0.6` to `>= 0.6.1, < 2`. This keeps existing 0.x versions supported and allows applications to resolve the secure `rack-proxy` 1.x releases, including 1.0.1.

## Validation

- `bundle install`
- `bundle exec ruby -Itest test/dev_server_proxy_test.rb`
- `bundle exec ruby -Itest test/compatibility_check_test.rb test/config_test.rb`
- `gem build vite_ruby.gemspec`

The full `bundle exec rake test` run reached the existing mounted-app dependency-update integration test and exceeded the local timeout without reporting a product test failure.