### PR TITLE
fix: support rack-proxy 1.0 (close #622)

### DIFF
--- a/test/dev_server_proxy_test.rb
+++ b/test/dev_server_proxy_test.rb
@@ -40,6 +40,14 @@ class DevServerProxyTest < ViteRuby::Test
     assert_forwarded to: "/vite-production/application.js"
   end
 
+  def test_forwards_to_configured_backend
+    get_with_dev_server_running "/vite-production/application.js"
+
+    env = JSON.parse(last_response.body)
+
+    assert_equal ViteRuby.config.origin, env["rack.backend"]
+  end
+
   def test_vite_client
     get_with_dev_server_running "/@vite/client"
 

--- a/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
+++ b/vite_ruby/lib/vite_ruby/dev_server_proxy.rb
@@ -44,6 +44,7 @@ private
   def forward_to_vite_dev_server(env)
     rewrite_uri_for_vite(env)
     env["QUERY_STRING"] ||= ""
+    env["rack.backend"] = URI(config.origin)
     env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = config.host
     env["HTTP_X_FORWARDED_SERVER"] = config.host_with_port
     env["HTTP_PORT"] = env["HTTP_X_FORWARDED_PORT"] = config.port.to_s


### PR DESCRIPTION
### Description 📖

This pull request makes `ViteRuby::DevServerProxy` compatible with **rack-proxy 1.0**, so proxied asset requests during development no longer fail with `502 Bad Gateway`. Closes #622.

### Background 📜

This was happening because #619 relaxed the dependency to `rack-proxy >= 0.6.1`, which lets bundler resolve rack-proxy 1.0. rack-proxy 1.0 refuses to derive a backend from the client-controlled `Host` header unless you explicitly opt in (an SSRF/open-proxy guard). `DevServerProxy` selected the Vite backend precisely by rewriting the `Host` header, so on rack-proxy 1.0 every proxied request returned `[502, {}, []]`:

```
rack-proxy: refusing Host-derived backend "localhost" (no :backend configured; pass allow_dynamic_backend: true to opt in)
```

### The Fix 🔨

By changing `forward_to_vite_dev_server` to set an explicit, config-derived backend on the request env rather than relying on the `Host` header:

```ruby
env["rack.backend"] = URI(config.origin)
```
